### PR TITLE
Remove "this should take 2 days" from the fast pass text in the online

### DIFF
--- a/app/views/home/dashboard.scala.html
+++ b/app/views/home/dashboard.scala.html
@@ -107,8 +107,7 @@
                             @if(dashboardPage.assessmentStageStatus == ASSESSMENT_FAST_PASS_CERTIFICATE) {
                                 <div data-sdip>
                                     <p id="fast-pass-msg">We need to check and verify your certificate number before
-                                        you can progress as a Fast Pass candidate. This should
-                                        take 2 working days.</p>
+                                        you can progress as a Fast Pass candidate.</p>
                                 </div>
                             } else {
                                 @onlineTestProgress(usr, dashboardPage, allocationDetails)


### PR DESCRIPTION
test dashboard.