### PR TITLE
Cache recovery on-unexpected-content (parse failure) tests

### DIFF
--- a/app/config/frontendWiring.scala
+++ b/app/config/frontendWiring.scala
@@ -58,8 +58,7 @@ object CSRCache extends CSRCache {
   )
 }
 
-object SecurityEnvironmentImpl extends security.SecurityEnvironment {
-
+trait SecurityEnvironmentImpl extends security.SecurityEnvironment {
   override lazy val eventBus: EventBus = EventBus()
 
   override val userService = new UserCacheService(ApplicationClient, UserManagementClient)
@@ -80,6 +79,8 @@ object SecurityEnvironmentImpl extends security.SecurityEnvironment {
   override def providers = Map(credentialsProvider.id -> credentialsProvider)
   val http: CSRHttp = CSRHttp
 }
+
+object SecurityEnvironmentImpl extends SecurityEnvironmentImpl
 
 object WhitelistFilter extends AkamaiWhitelistFilter with RunMode {
 

--- a/app/controllers/ActivationController.scala
+++ b/app/controllers/ActivationController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import _root_.forms.ActivateAccountForm
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.UserManagementClient.{ TokenEmailPairInvalidException, TokenExpiredException }
 import helpers.NotificationType._
@@ -26,11 +26,13 @@ import security.SignInService
 
 import scala.concurrent.Future
 
-object ActivationController extends ActivationController(ApplicationClient) {
+object ActivationController extends ActivationController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class ActivationController(val applicationClient: ApplicationClient) extends BaseController(applicationClient) with SignInService {
+abstract class ActivationController(val applicationClient: ApplicationClient,
+                                    cacheClient: CSRCache) extends
+  BaseController(applicationClient, cacheClient) with SignInService {
 
   def present = CSRSecureAction(NoRole) { implicit request =>
     implicit user => user.user.isActive match {

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import play.api.mvc.Action
 
@@ -25,11 +25,12 @@ import scala.concurrent.Future
 /**
  * Provide all the peripheral links from this controller, like T&C link
  */
-object ApplicationController extends ApplicationController(ApplicationClient) {
+object ApplicationController extends ApplicationController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class ApplicationController(val applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+abstract class ApplicationController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def index = Action {
     Redirect(routes.SignInController.signIn())

--- a/app/controllers/AssistanceDetailsController.scala
+++ b/app/controllers/AssistanceDetailsController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import _root_.forms.AssistanceDetailsForm
+import config.CSRCache
 import connectors.ApplicationClient
 import connectors.ApplicationClient.AssistanceDetailsNotFound
 import models.CachedData
@@ -25,9 +26,10 @@ import security.Roles.AssistanceDetailsRole
 
 import scala.concurrent.Future
 
-object AssistanceDetailsController extends AssistanceDetailsController(ApplicationClient)
+object AssistanceDetailsController extends AssistanceDetailsController(ApplicationClient, CSRCache)
 
-class AssistanceDetailsController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+class AssistanceDetailsController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def present = CSRSecureAppAction(AssistanceDetailsRole) { implicit request =>
     implicit user =>

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import java.time.LocalDateTime
 
-import config.FaststreamFrontendConfig
+import config.{ CSRCache, FaststreamFrontendConfig, SecurityEnvironmentImpl }
 import connectors.ApplicationClient
 import connectors.ApplicationClient.ApplicationNotFound
 import connectors.exchange.FrameworkId
@@ -45,7 +45,9 @@ object FaststreamConfig {
 /**
  * should be extended by all controllers
  */
-abstract class BaseController(applicationClient: ApplicationClient) extends FrontendController with SecureActions {
+abstract class BaseController(applicationClient: ApplicationClient) extends SecureActions(SecurityEnvironmentImpl, CSRCache)
+with FrontendController
+   {
 
   implicit val feedbackUrl = config.FrontendAppConfig.feedbackUrl
   implicit def faststreamConfig = FaststreamConfig(config.FrontendAppConfig.faststreamFrontendConfig)

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -25,7 +25,7 @@ import connectors.exchange.FrameworkId
 import helpers.NotificationType._
 import models.{ CachedData, CachedDataWithApp }
 import play.api.mvc.Request
-import security.SecureActions
+import security.{ SecureActions, SecurityEnvironment }
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import uk.gov.hmrc.play.http.HeaderCarrier
 
@@ -45,7 +45,7 @@ object FaststreamConfig {
 /**
  * should be extended by all controllers
  */
-abstract class BaseController(applicationClient: ApplicationClient) extends SecureActions(SecurityEnvironmentImpl, CSRCache)
+abstract class BaseController(applicationClient: ApplicationClient, val cacheClient: CSRCache) extends SecureActions
 with FrontendController
    {
 

--- a/app/controllers/CubiksTestController.scala
+++ b/app/controllers/CubiksTestController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.exchange.CubiksTest
 import models.UniqueIdentifier
@@ -25,11 +25,12 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-object CubiksTestController extends CubiksTestController(ApplicationClient) {
+object CubiksTestController extends CubiksTestController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class CubiksTestController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+abstract class CubiksTestController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def startPhase1Tests = CSRSecureAppAction(OnlineTestInvitedRole) { implicit request =>
     implicit cachedUserData =>

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import _root_.forms.WithdrawApplicationForm
+import config.CSRCache
 import connectors.ApplicationClient
 import connectors.ApplicationClient.{ CannotWithdraw, OnlineTestNotFound }
 import connectors.exchange.{ FrameworkId, Phase2TestGroupWithNames, WithdrawApplication }
@@ -29,9 +30,9 @@ import security.Roles._
 
 import scala.concurrent.Future
 
-object HomeController extends HomeController(ApplicationClient)
+object HomeController extends HomeController(ApplicationClient, CSRCache)
 
-class HomeController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+class HomeController(applicationClient: ApplicationClient, cacheClient: CSRCache) extends BaseController(applicationClient, cacheClient) {
   val Withdrawer = "Candidate"
 
   val present = CSRSecureAction(ActiveUserRole) { implicit request => implicit cachedData =>

--- a/app/controllers/LockAccountController.scala
+++ b/app/controllers/LockAccountController.scala
@@ -17,16 +17,17 @@
 package controllers
 
 import _root_.forms.LockAccountForm
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 
 import scala.concurrent.Future
 
-object LockAccountController extends LockAccountController(ApplicationClient) {
+object LockAccountController extends LockAccountController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class LockAccountController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+abstract class LockAccountController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def present = CSRUserAwareAction { implicit request =>
     implicit user =>

--- a/app/controllers/PartnerGraduateProgrammesController.scala
+++ b/app/controllers/PartnerGraduateProgrammesController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import _root_.forms.PartnerGraduateProgrammesForm
+import config.CSRCache
 import connectors.ApplicationClient
 import connectors.ApplicationClient.PartnerGraduateProgrammesNotFound
 import connectors.exchange.PartnerGraduateProgrammes
@@ -24,9 +25,10 @@ import security.Roles.PartnerGraduateProgrammesRole
 
 import scala.concurrent.Future
 
-object PartnerGraduateProgrammesController extends PartnerGraduateProgrammesController(ApplicationClient)
+object PartnerGraduateProgrammesController extends PartnerGraduateProgrammesController(ApplicationClient, CSRCache)
 
-class PartnerGraduateProgrammesController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+class PartnerGraduateProgrammesController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def present = CSRSecureAppAction(PartnerGraduateProgrammesRole) { implicit request =>
     implicit user =>

--- a/app/controllers/PasswordResetController.scala
+++ b/app/controllers/PasswordResetController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import _root_.forms.{ RequestResetPasswordForm, ResetPasswordForm, SignInForm }
 import com.mohiva.play.silhouette.api.util.Credentials
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.UserManagementClient.{ InvalidEmailException, TokenEmailPairInvalidException, TokenExpiredException }
 import helpers.NotificationType._
@@ -27,11 +27,12 @@ import security.{ InvalidRole, SignInService }
 
 import scala.concurrent.Future
 
-object PasswordResetController extends PasswordResetController(ApplicationClient) {
+object PasswordResetController extends PasswordResetController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class PasswordResetController(val applicationClient: ApplicationClient) extends BaseController(applicationClient) with SignInService {
+abstract class PasswordResetController(val applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) with SignInService {
 
   def presentCode() = CSRUserAwareAction { implicit request =>
     implicit user =>

--- a/app/controllers/PersonalDetailsController.scala
+++ b/app/controllers/PersonalDetailsController.scala
@@ -20,6 +20,7 @@ import _root_.forms.GeneralDetailsForm
 import connectors.ApplicationClient.PersonalDetailsNotFound
 import connectors.{ ApplicationClient, UserManagementClient }
 import _root_.forms.FastPassForm._
+import config.CSRCache
 import connectors.exchange.CivilServiceExperienceDetails
 import helpers.NotificationType._
 import mappings.{ Address, DayMonthYear }
@@ -33,10 +34,10 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-object PersonalDetailsController extends PersonalDetailsController(ApplicationClient, UserManagementClient)
+object PersonalDetailsController extends PersonalDetailsController(ApplicationClient, CSRCache, UserManagementClient)
 
-class PersonalDetailsController(applicationClient: ApplicationClient, userManagementClient: UserManagementClient)
-  extends BaseController(applicationClient) with GeneralDetailsToExchangeConverter {
+class PersonalDetailsController(applicationClient: ApplicationClient, cacheClient: CSRCache, userManagementClient: UserManagementClient)
+  extends BaseController(applicationClient, cacheClient) with GeneralDetailsToExchangeConverter {
 
   private sealed trait OnSuccess
   private case object ContinueToNextStepInJourney extends OnSuccess

--- a/app/controllers/PreviewApplicationController.scala
+++ b/app/controllers/PreviewApplicationController.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.CSRCache
 import connectors.ApplicationClient.{ AssistanceDetailsNotFound, PartnerGraduateProgrammesNotFound, PersonalDetailsNotFound }
 import connectors.SchemeClient.SchemePreferencesNotFound
 import connectors.{ ApplicationClient, SchemeClient }
@@ -24,10 +25,10 @@ import security.Roles.PreviewApplicationRole
 
 import scala.concurrent.Future
 
-object PreviewApplicationController extends PreviewApplicationController(ApplicationClient, SchemeClient)
+object PreviewApplicationController extends PreviewApplicationController(ApplicationClient, CSRCache, SchemeClient)
 
-class PreviewApplicationController(applicationClient: ApplicationClient, schemeClient: SchemeClient) extends
-  BaseController(applicationClient) {
+class PreviewApplicationController(applicationClient: ApplicationClient, cacheClient: CSRCache, schemeClient: SchemeClient) extends
+  BaseController(applicationClient, cacheClient) {
 
   def present = CSRSecureAppAction(PreviewApplicationRole) { implicit request =>
     implicit user =>

--- a/app/controllers/QuestionnaireController.scala
+++ b/app/controllers/QuestionnaireController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import _root_.forms.{ DiversityQuestionnaireForm, EducationQuestionnaireForm, ParentalOccupationQuestionnaireForm }
+import config.CSRCache
 import connectors.ApplicationClient
 import connectors.exchange.Questionnaire
 import helpers.NotificationType._
@@ -29,9 +30,10 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 import scala.concurrent.Future
 import scala.language.reflectiveCalls
 
-object QuestionnaireController extends QuestionnaireController(ApplicationClient)
+object QuestionnaireController extends QuestionnaireController(ApplicationClient, CSRCache)
 
-class QuestionnaireController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+class QuestionnaireController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   val QuestionnaireCompletedBanner = danger("questionnaire.completed")
 

--- a/app/controllers/SchemePreferencesController.scala
+++ b/app/controllers/SchemePreferencesController.scala
@@ -17,14 +17,17 @@
 package controllers
 
 import _root_.forms.SelectedSchemesForm._
+import config.CSRCache
 import connectors.SchemeClient.SchemePreferencesNotFound
 import connectors.{ ApplicationClient, SchemeClient }
 import security.Roles.SchemesRole
 
 import scala.concurrent.Future
 
-class SchemePreferencesController(applicationClient: ApplicationClient, schemeClient: SchemeClient) extends
-  BaseController(applicationClient){
+object SchemePreferencesController extends SchemePreferencesController(ApplicationClient, CSRCache, SchemeClient)
+
+class SchemePreferencesController(applicationClient: ApplicationClient, cacheClient: CSRCache, schemeClient: SchemeClient) extends
+  BaseController(applicationClient, cacheClient){
 
   def present = CSRSecureAppAction(SchemesRole) { implicit request =>
     implicit user =>
@@ -63,5 +66,3 @@ class SchemePreferencesController(applicationClient: ApplicationClient, schemeCl
     )
   }
 }
-
-object SchemePreferencesController extends SchemePreferencesController(ApplicationClient, SchemeClient)

--- a/app/controllers/SchoolsController.scala
+++ b/app/controllers/SchoolsController.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.CSRCache
 import connectors.{ ApplicationClient, SchoolsClient }
 import connectors.SchoolsClient.SchoolsNotFound
 import models.view.SchoolView
@@ -29,9 +30,10 @@ import uk.gov.hmrc.play.frontend.controller.FrontendController
 import scala.concurrent.Future
 import scala.language.reflectiveCalls
 
-object SchoolsController extends SchoolsController(SchoolsClient, ApplicationClient)
+object SchoolsController extends SchoolsController(SchoolsClient, CSRCache, ApplicationClient)
 
-class SchoolsController(schoolsClient: SchoolsClient, applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+class SchoolsController(schoolsClient: SchoolsClient, cacheClient: CSRCache, applicationClient: ApplicationClient)
+  extends BaseController(applicationClient, cacheClient) {
   def getSchools(term: String) = CSRSecureAppAction(EducationQuestionnaireRole) { implicit request =>
     implicit user =>
       if (term.trim.nonEmpty) {

--- a/app/controllers/SchoolsController.scala
+++ b/app/controllers/SchoolsController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.SchoolsClient
+import connectors.{ ApplicationClient, SchoolsClient }
 import connectors.SchoolsClient.SchoolsNotFound
 import models.view.SchoolView
 import models.view.SchoolView._
@@ -29,9 +29,9 @@ import uk.gov.hmrc.play.frontend.controller.FrontendController
 import scala.concurrent.Future
 import scala.language.reflectiveCalls
 
-object SchoolsController extends SchoolsController(SchoolsClient)
+object SchoolsController extends SchoolsController(SchoolsClient, ApplicationClient)
 
-class SchoolsController(schoolsClient: SchoolsClient) extends FrontendController with SecureActions {
+class SchoolsController(schoolsClient: SchoolsClient, applicationClient: ApplicationClient) extends BaseController(applicationClient) {
   def getSchools(term: String) = CSRSecureAppAction(EducationQuestionnaireRole) { implicit request =>
     implicit user =>
       if (term.trim.nonEmpty) {

--- a/app/controllers/SignInController.scala
+++ b/app/controllers/SignInController.scala
@@ -32,11 +32,12 @@ import security.{ SignInService, _ }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-object SignInController extends SignInController(ApplicationClient) with SignInService {
+object SignInController extends SignInController(ApplicationClient, CSRCache) with SignInService {
   val http = CSRHttp
 }
 
-abstract class SignInController(val applicationClient: ApplicationClient) extends BaseController(applicationClient) with SignInService {
+abstract class SignInController(val applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) with SignInService {
 
   def present = CSRUserAwareAction { implicit request =>
     implicit user =>

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -19,7 +19,7 @@ package controllers
 import _root_.forms.SignUpForm
 import _root_.forms.SignUpForm._
 import com.mohiva.play.silhouette.api.SignUpEvent
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.UserManagementClient.EmailTakenException
 import connectors.exchange.Implicits._
@@ -29,15 +29,15 @@ import security.SignInService
 
 import scala.concurrent.Future
 
-object SignUpController extends SignUpController(ApplicationClient) {
+object SignUpController extends SignUpController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class SignUpController(val applicationClient: ApplicationClient) extends BaseController(applicationClient) with SignInService {
+abstract class SignUpController(val applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) with SignInService {
 
   def present = CSRUserAwareAction { implicit request =>
     implicit user =>
-
       Future.successful(request.identity match {
         case Some(_) => Redirect(routes.HomeController.present()).flashing(warning("activation.already"))
         case None => Ok(views.html.registration.signup(SignUpForm.form))

--- a/app/controllers/SubmitApplicationController.scala
+++ b/app/controllers/SubmitApplicationController.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.CSRCache
 import connectors.ApplicationClient
 import connectors.ApplicationClient.CannotSubmit
 import helpers.NotificationType._
@@ -25,9 +26,10 @@ import security.Roles.{ SubmitApplicationRole, WithdrawApplicationRole }
 
 import scala.concurrent.Future
 
-object SubmitApplicationController extends SubmitApplicationController(ApplicationClient)
+object SubmitApplicationController extends SubmitApplicationController(ApplicationClient, CSRCache)
 
-class SubmitApplicationController(applicationClient: ApplicationClient) extends BaseController(applicationClient) {
+class SubmitApplicationController(applicationClient: ApplicationClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def present = CSRSecureAppAction(SubmitApplicationRole) { implicit request =>
     implicit user =>

--- a/app/controllers/testdata/TestDataGeneratorRedirectController.scala
+++ b/app/controllers/testdata/TestDataGeneratorRedirectController.scala
@@ -16,18 +16,18 @@
 
 package controllers.testdata
 
-import config.CSRHttp
-import connectors.{ApplicationClient, TestDataClient}
+import config.{ CSRCache, CSRHttp }
+import connectors.{ ApplicationClient, TestDataClient }
 import controllers.BaseController
 
 import scala.concurrent.Future
 
-object TestDataGeneratorRedirectController extends TestDataGeneratorRedirectController(ApplicationClient) {
+object TestDataGeneratorRedirectController extends TestDataGeneratorRedirectController(ApplicationClient, CSRCache) {
   val http = CSRHttp
 }
 
-abstract class TestDataGeneratorRedirectController(applicationClient: ApplicationClient with TestDataClient)
-  extends BaseController(applicationClient) {
+abstract class TestDataGeneratorRedirectController(applicationClient: ApplicationClient with TestDataClient, cacheClient: CSRCache)
+  extends BaseController(applicationClient, cacheClient) {
 
   def generateTestData(path: String) = CSRUserAwareAction { implicit request =>
     implicit user =>

--- a/app/security/Roles.scala
+++ b/app/security/Roles.scala
@@ -42,7 +42,7 @@ object Roles {
       activeUserWithApp(user) && isEnabled(user)
   }
 
-  //all the roles
+  // All the roles
 
   object NoRole extends CsrAuthorization {
     override def isAuthorized(user: CachedData)(implicit request: RequestHeader, lang: Lang) = true

--- a/app/security/SecureActions.scala
+++ b/app/security/SecureActions.scala
@@ -76,16 +76,13 @@ trait SecureActions extends Silhouette[SecurityUser, SessionAuthenticator] {
     */
   def CSRSecureAction(role: CsrAuthorization)(block: SecuredRequest[_] => CachedData => Future[Result])
   : Action[AnyContent] = {
-    val result = SecuredAction.async { secondRequest =>
+    SecuredAction.async { secondRequest =>
       implicit val carrier = hc(secondRequest.request)
       getCachedData(secondRequest.identity)(carrier, secondRequest).flatMap {
-        case Some(data) => print("Going to SAWC")
-          SecuredActionWithCSRAuthorisation(secondRequest, block, role, data, data)
-        case None => print("None received!")
-          gotoAuthentication(secondRequest)
+        case Some(data) => SecuredActionWithCSRAuthorisation(secondRequest, block, role, data, data)
+        case None => gotoAuthentication(secondRequest)
       }
     }
-    result
   }
 
   def CSRSecureAppAction(role: CsrAuthorization)

--- a/app/security/UserCacheService.scala
+++ b/app/security/UserCacheService.scala
@@ -35,7 +35,6 @@ import scala.util.{Failure, Success, Try}
 class UserCacheService(applicationClient: ApplicationClient, userManagementClient: UserManagementClient) extends UserService {
 
   override def retrieve(loginInfo: LoginInfo): Future[Option[SecurityUser]] = {
-    Logger.debug("Called Retrieve!")
     Future.successful(Some(SecurityUser(userID = loginInfo.providerKey)))
   }
 
@@ -43,7 +42,6 @@ class UserCacheService(applicationClient: ApplicationClient, userManagementClien
     CSRCache.cache[CachedData](user.user.userID.toString(), user).map(_ => user)
 
   override def refreshCachedUser(userId: UniqueIdentifier)(implicit hc: HeaderCarrier, request: Request[_]): Future[CachedData] = {
-    Logger.debug("Called Refresh!")
     userManagementClient.findByUserId(userId).flatMap { userData =>
       applicationClient.findApplication(userId, FrameworkId).flatMap { appData =>
         val cd = CachedData(userData.toCached, Some(appData))

--- a/app/security/UserCacheService.scala
+++ b/app/security/UserCacheService.scala
@@ -18,25 +18,21 @@ package security
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import config.CSRCache
-import connectors.{ApplicationClient, UserManagementClient}
+import connectors.{ ApplicationClient, UserManagementClient }
 import connectors.ApplicationClient.ApplicationNotFound
 import connectors.exchange._
-import models.{CachedData, CachedDataWithApp, SecurityUser, UniqueIdentifier}
+import models.{ CachedData, SecurityUser, UniqueIdentifier }
 import play.api.mvc.Request
 import uk.gov.hmrc.play.http.HeaderCarrier
 import Implicits.exchangeUserToCachedUser
-import connectors.UserManagementClient.InvalidCredentialsException
-import play.api.Logger
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
 
 class UserCacheService(applicationClient: ApplicationClient, userManagementClient: UserManagementClient) extends UserService {
 
-  override def retrieve(loginInfo: LoginInfo): Future[Option[SecurityUser]] = {
+  override def retrieve(loginInfo: LoginInfo): Future[Option[SecurityUser]] =
     Future.successful(Some(SecurityUser(userID = loginInfo.providerKey)))
-  }
 
   override def save(user: CachedData)(implicit hc: HeaderCarrier): Future[CachedData] =
     CSRCache.cache[CachedData](user.user.userID.toString(), user).map(_ => user)

--- a/test/config/LockAccountControllerSpec.scala
+++ b/test/config/LockAccountControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.CSRCache
 import connectors.ApplicationClient
 import play.api.mvc._
 import play.api.test.Helpers._
@@ -76,12 +77,13 @@ class LockAccountControllerSpec extends BaseControllerSpec {
     implicit val hc: HeaderCarrier = HeaderCarrier()
 
     val mockApplicationClient = mock[ApplicationClient]
+    val mockCacheClient = mock[CSRCache]
     val mockEnvironment = mock[SecurityEnvironment]
 
-    class TestableLockAccountController extends LockAccountController(mockApplicationClient) {
+    class TestableLockAccountController extends LockAccountController(mockApplicationClient, mockCacheClient) {
       override protected def env = mockEnvironment
     }
 
-    def lockAccountController = new LockAccountController(mockApplicationClient) with NoIdentityTestableCSRUserAwareAction
+    def lockAccountController = new LockAccountController(mockApplicationClient, mockCacheClient) with NoIdentityTestableCSRUserAwareAction
   }
 }

--- a/test/controllers/ActivationControllerSpec.scala
+++ b/test/controllers/ActivationControllerSpec.scala
@@ -16,12 +16,13 @@
 
 package controllers
 
+import config.CSRCache
 import connectors.ApplicationClient
-import connectors.UserManagementClient.{TokenEmailPairInvalidException, TokenExpiredException}
+import connectors.UserManagementClient.{ TokenEmailPairInvalidException, TokenExpiredException }
 import models.CachedData
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.Matchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
-import play.api.mvc.{Request, Result, Results}
+import play.api.mvc.{ Request, Result, Results }
 import play.api.test.Helpers._
 import security.SignInService
 
@@ -29,12 +30,13 @@ import scala.concurrent.Future
 
 class ActivationControllerSpec extends BaseControllerSpec {
   val mockApplicationClient = mock[ApplicationClient]
+  val mockCacheClient = mock[CSRCache]
   val mockEnvironment = mock[security.SecurityEnvironment]
   val mockSignInService = mock[SignInService]
 
   import models.SecurityUserExamples._
 
-  class TestableActivationController extends ActivationController(mockApplicationClient) with TestableSignInService
+  class TestableActivationController extends ActivationController(mockApplicationClient, mockCacheClient) with TestableSignInService
     with TestableSecureActions {
     val signInService = mockSignInService
     override protected def env = mockEnvironment

--- a/test/controllers/ApplicationControllerSpec.scala
+++ b/test/controllers/ApplicationControllerSpec.scala
@@ -16,13 +16,14 @@
 
 package controllers
 
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 
 class ApplicationControllerSpec extends BaseControllerSpec {
-  val applicationClient = mock[ApplicationClient]
+  val mockApplicationClient = mock[ApplicationClient]
+  val mockCacheClient = mock[CSRCache]
 
-  class TestableApplicationController extends ApplicationController(applicationClient) with TestableSecureActions {
+  class TestableApplicationController extends ApplicationController(mockApplicationClient, mockCacheClient) with TestableSecureActions {
     val http: CSRHttp = CSRHttp
     override protected def env = securityEnvironment
   }

--- a/test/controllers/AssistanceDetailsControllerSpec.scala
+++ b/test/controllers/AssistanceDetailsControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock.{ any => _ }
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.ApplicationClient.AssistanceDetailsNotFound
 import connectors.exchange.AssistanceDetailsExamples
@@ -114,9 +114,10 @@ class AssistanceDetailsControllerSpec extends BaseControllerSpec {
 
   trait TestFixture {
     val mockApplicationClient = mock[ApplicationClient]
+    val mockCacheClient = mock[CSRCache]
     val mockUserService = mock[UserService]
 
-    class TestableAssistanceDetailsController extends AssistanceDetailsController(mockApplicationClient)
+    class TestableAssistanceDetailsController extends AssistanceDetailsController(mockApplicationClient, mockCacheClient)
       with TestableSecureActions {
       val http: CSRHttp = CSRHttp
 

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -88,9 +88,6 @@ abstract class BaseControllerSpec extends BaseSpec with ScalaFutures {
     redirectLocation(result) must be(Some(expectedUrl))
   }
 
-  val mockSecurityEnv = mock[SecurityEnvironment]
-  val mockCSRCache = mock[CSRCache]
-
   // scalastyle:off method.name
   trait TestableSecureActions extends SecureActions {
 

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -92,7 +92,7 @@ abstract class BaseControllerSpec extends BaseSpec with ScalaFutures {
   val mockCSRCache = mock[CSRCache]
 
   // scalastyle:off method.name
-  abstr TestableSecureActions extends SecureActions(mockSecurityEnv, mockCSRCache) {
+  trait TestableSecureActions extends SecureActions {
 
     val Candidate: CachedData = currentCandidate
     val CandidateWithApp: CachedDataWithApp = currentCandidateWithApp

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
+import config.CSRCache
 import models.SecurityUserExamples._
 import models._
 import org.joda.time.DateTime
@@ -29,7 +30,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.filters.csrf.CSRF
 import security.Roles.CsrAuthorization
-import security.{SecureActions, SecurityEnvironment, SignInService}
+import security.{ SecureActions, SecurityEnvironment, SignInService }
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -87,8 +88,11 @@ abstract class BaseControllerSpec extends BaseSpec with ScalaFutures {
     redirectLocation(result) must be(Some(expectedUrl))
   }
 
+  val mockSecurityEnv = mock[SecurityEnvironment]
+  val mockCSRCache = mock[CSRCache]
+
   // scalastyle:off method.name
-  trait TestableSecureActions extends SecureActions {
+  abstr TestableSecureActions extends SecureActions(mockSecurityEnv, mockCSRCache) {
 
     val Candidate: CachedData = currentCandidate
     val CandidateWithApp: CachedDataWithApp = currentCandidateWithApp

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock.{ any => _ }
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.ApplicationClient.{ AssistanceDetailsNotFound, CannotWithdraw }
 import connectors.exchange.{ AssistanceDetailsExamples, WithdrawApplicationExamples }
@@ -102,9 +102,10 @@ class HomeControllerSpec extends BaseControllerSpec {
 
   trait TestFixture {
     val mockApplicationClient = mock[ApplicationClient]
+    val mockCacheClient = mock[CSRCache]
     val mockUserService = mock[UserService]
 
-    class TestableHomeController extends HomeController(mockApplicationClient)
+    class TestableHomeController extends HomeController(mockApplicationClient, mockCacheClient)
       with TestableSecureActions {
       val http: CSRHttp = CSRHttp
       override protected def env = securityEnvironment

--- a/test/controllers/PartnerGraduateProgrammesControllerSpec.scala
+++ b/test/controllers/PartnerGraduateProgrammesControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock.{ any => _ }
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.ApplicationClient
 import connectors.ApplicationClient.PartnerGraduateProgrammesNotFound
 import connectors.exchange.PartnerGraduateProgrammesExamples
@@ -85,10 +85,11 @@ class PartnerGraduateProgrammesControllerSpec extends BaseControllerSpec {
 
   trait TestFixture {
     val mockApplicationClient = mock[ApplicationClient]
+    val mockCacheClient = mock[CSRCache]
     val mockSecurityEnvironment = mock[security.SecurityEnvironment]
     val mockUserService = mock[UserService]
 
-    class TestablePartnerGraduateProgrammesController extends PartnerGraduateProgrammesController(mockApplicationClient)
+    class TestablePartnerGraduateProgrammesController extends PartnerGraduateProgrammesController(mockApplicationClient, mockCacheClient)
       with TestableSecureActions {
       val http: CSRHttp = CSRHttp
       override protected def env = mockSecurityEnvironment

--- a/test/controllers/PreviewApplicationControllerSpec.scala
+++ b/test/controllers/PreviewApplicationControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock.{ any => _ }
-import config.CSRHttp
+import config.{ CSRCache, CSRHttp }
 import connectors.{ ApplicationClient, SchemeClient }
 import connectors.ApplicationClient.{ AssistanceDetailsNotFound, CannotUpdateRecord, PartnerGraduateProgrammesNotFound, PersonalDetailsNotFound }
 import connectors.SchemeClient.SchemePreferencesNotFound
@@ -104,6 +104,7 @@ class PreviewApplicationControllerSpec extends BaseControllerSpec {
 
   trait TestFixture {
     val mockApplicationClient = mock[ApplicationClient]
+    val mockCacheClient = mock[CSRCache]
     val mockSchemeClient = mock[SchemeClient]
     val mockSecurityEnvironment = mock[security.SecurityEnvironment]
     val mockUserService = mock[UserService]
@@ -117,7 +118,7 @@ class PreviewApplicationControllerSpec extends BaseControllerSpec {
     when(mockApplicationClient.getPartnerGraduateProgrammes(eqTo(currentApplicationId))(any[HeaderCarrier]))
       .thenReturn(Future.successful(PartnerGraduateProgrammesExamples.InterestedNotAll))
 
-    class TestablePreviewApplicationController extends PreviewApplicationController(mockApplicationClient,
+    class TestablePreviewApplicationController extends PreviewApplicationController(mockApplicationClient, mockCacheClient,
       mockSchemeClient)
       with TestableSecureActions {
       val http: CSRHttp = CSRHttp

--- a/test/controllers/QuestionnaireControllerSpec.scala
+++ b/test/controllers/QuestionnaireControllerSpec.scala
@@ -16,23 +16,26 @@
 
 package controllers
 
+import config.CSRCache
 import connectors.ApplicationClient
 import models.CachedDataWithApp
 import models.Progress
 import models.ApplicationData.ApplicationStatus._
 import play.api.test.Helpers._
 import play.api.mvc.Result
+
 import scala.concurrent._
 
 
 class QuestionnaireControllerSpec extends BaseControllerSpec {
 
   val applicationClient = mock[ApplicationClient]
+  val mockCacheClient = mock[CSRCache]
   val candidateWithApp = currentCandidateWithApp.copy(
     application = currentCandidateWithApp.application.copy(applicationStatus = IN_PROGRESS))
   val errorContent = "You've now completed this part of the application and for security reasons you can't go back and change your answers."
 
-  def controllerUnderTest(appStatus: Progress) = new QuestionnaireController(applicationClient) with TestableSecureActions {
+  def controllerUnderTest(appStatus: Progress) = new QuestionnaireController(applicationClient, mockCacheClient) with TestableSecureActions {
     override val CandidateWithApp: CachedDataWithApp = candidateWithApp
       .copy(application = candidateWithApp.application.copy(progress = appStatus))
   }

--- a/test/controllers/QuestionnaireControllerSpec.scala
+++ b/test/controllers/QuestionnaireControllerSpec.scala
@@ -23,9 +23,7 @@ import models.Progress
 import models.ApplicationData.ApplicationStatus._
 import play.api.test.Helpers._
 import play.api.mvc.Result
-
 import scala.concurrent._
-
 
 class QuestionnaireControllerSpec extends BaseControllerSpec {
 

--- a/test/controllers/SchemePreferencesControllerSpec.scala
+++ b/test/controllers/SchemePreferencesControllerSpec.scala
@@ -22,6 +22,7 @@ import models._
 import org.mockito.Matchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
 import _root_.forms.SelectedSchemesForm._
+import config.CSRCache
 import connectors.exchange.{ ApplicationResponse, CivilServiceExperienceDetails, SchemePreferencesExamples }
 import connectors.exchange.CivilServiceExperienceDetailsExamples._
 import models.ApplicationData.ApplicationStatus
@@ -36,10 +37,11 @@ import scala.concurrent.Future
 class SchemePreferencesControllerSpec extends BaseControllerSpec {
 
   val applicationClient = mock[ApplicationClient]
+  val mockCacheClient = mock[CSRCache]
   val schemeClient  = mock[SchemeClient]
   val userService = mock[UserService]
 
-  def controllerUnderTest = new SchemePreferencesController(applicationClient, schemeClient) with TestableSecureActions {
+  def controllerUnderTest = new SchemePreferencesController(applicationClient, mockCacheClient, schemeClient) with TestableSecureActions {
     override protected def env = securityEnvironment
     when(userService.refreshCachedUser(any[UniqueIdentifier])(any[HeaderCarrier], any())).thenReturn(Future.successful(CachedData(
       mock[CachedUser],

--- a/test/controllers/SchoolsControllerSpec.scala
+++ b/test/controllers/SchoolsControllerSpec.scala
@@ -16,7 +16,8 @@
 
 package controllers
 
-import connectors.SchoolsClient
+import config.CSRCache
+import connectors.{ ApplicationClient, SchoolsClient }
 import connectors.SchoolsClient.SchoolsNotFound
 import connectors.exchange.School
 import org.mockito.Matchers.{ eq => eqTo, _ }
@@ -30,8 +31,10 @@ import scala.concurrent.Future
 class SchoolsControllerSpec extends BaseControllerSpec {
 
   val schoolClient = mock[SchoolsClient]
+  val mockCacheClient = mock[CSRCache]
+  val mockApplicationClient = mock[ApplicationClient]
 
-  def schoolsController = new SchoolsController(schoolClient) with TestableSecureActions
+  def schoolsController = new SchoolsController(schoolClient, mockCacheClient, mockApplicationClient) with TestableSecureActions
 
   "get schools" should {
     val schoolList = List(

--- a/test/controllers/SignInControllerSpec.scala
+++ b/test/controllers/SignInControllerSpec.scala
@@ -17,15 +17,16 @@
 package controllers
 
 import com.mohiva.play.silhouette.api.EventBus
-import com.mohiva.play.silhouette.impl.authenticators.{SessionAuthenticator, SessionAuthenticatorService}
+import com.mohiva.play.silhouette.impl.authenticators.{ SessionAuthenticator, SessionAuthenticatorService }
+import config.CSRCache
 import connectors.ApplicationClient
 import models.CachedDataExample
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.Matchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
-import play.api.mvc.{Flash, Request, Result, Results}
+import play.api.mvc.{ Flash, Request, Result, Results }
 import play.api.test.Helpers._
 import security._
-import testables.{NoIdentityTestableCSRUserAwareAction, TestableCSRUserAwareAction}
+import testables.{ NoIdentityTestableCSRUserAwareAction, TestableCSRUserAwareAction }
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -194,6 +195,7 @@ class SignInControllerSpec extends BaseControllerSpec {
     )
 
     val mockApplicationClient = mock[ApplicationClient]
+    val mockCacheClient = mock[CSRCache]
     val mockSignInService = mock[SignInService]
 
     val mockEnvironment = mock[SecurityEnvironment]
@@ -207,7 +209,7 @@ class SignInControllerSpec extends BaseControllerSpec {
     val mockAuthenticator = mock[SessionAuthenticator]
 
 
-    class TestableSignInController extends SignInController(mockApplicationClient) with TestableSignInService {
+    class TestableSignInController extends SignInController(mockApplicationClient, mockCacheClient) with TestableSignInService {
       override val signInService = mockSignInService
       override protected def env = mockEnvironment
     }

--- a/test/security/SecureActionsSpec.scala
+++ b/test/security/SecureActionsSpec.scala
@@ -18,53 +18,33 @@ package security
 
 import java.util.UUID
 
-import com.mohiva.play.silhouette.api.actions.SecuredRequest
-import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService, IdentityService }
-import com.mohiva.play.silhouette.api.util.{ Clock, FingerprintGenerator }
-import com.mohiva.play.silhouette.api.{ Environment, EventBus, LoginInfo, Provider }
-import com.mohiva.play.silhouette.impl.User
-import com.mohiva.play.silhouette.test._
-import com.mohiva.play.silhouette.impl.authenticators._
-import com.mohiva.play.silhouette.impl.util.DefaultFingerprintGenerator
-import com.mohiva.play.silhouette.test.FakeEnvironment
-import config.{ CSRCache, CSRHttp, SecurityEnvironmentImpl }
-import connectors.{ ApplicationClient, UserManagementClient }
+import config.{ CSRCache, SecurityEnvironmentImpl }
 import controllers.BaseSpec
 import models.{ CachedData, CachedUser, SecurityUser, UniqueIdentifier }
-import org.joda.time.DateTime
-import org.scalatest.MustMatchers
-import org.scalatestplus.play.PlaySpec
-import play.api.mvc.{ AnyContent, Request, Result }
-import play.api.test.Helpers._
-import security.Roles.{ CsrAuthorization, NoRole }
-import security._
-
-import scala.concurrent.Future
 import org.mockito.Matchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
+import org.scalatest.MustMatchers
 import org.scalatest.concurrent.ScalaFutures
-import play.api.Play
 import play.api.libs.json.{ JsString, Reads }
-import uk.gov.hmrc.play.http.HeaderCarrier
-import play.api.mvc.Results._
+import play.api.mvc.Request
 import play.api.test.FakeRequest
-import play.filters.csrf.CSRF
+import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.KeyStoreEntryValidationException
+import uk.gov.hmrc.play.http.HeaderCarrier
 
-import language.postfixOps
+import scala.concurrent.Future
+import scala.language.postfixOps
 
 class SecureActionsSpec extends BaseSpec with MustMatchers with ScalaFutures {
 
   "getCachedData" should {
     "return cachedData when parsing succeeds" in new TestFixture {
-
       val result = successfulCacheParseController.getCachedData(testSecurityUser).futureValue
 
       result.get mustBe an[CachedData]
     }
 
-    "Call for cache refresh when a parsing error occurs" in new TestFixture {
-
+    "call for cache refresh when a parsing error occurs" in new TestFixture {
       val result = unSuccessfulCacheParseController.getCachedData(testSecurityUser).futureValue
 
       result.get mustBe an[CachedData]

--- a/test/security/UserCacheServiceSpec.scala
+++ b/test/security/UserCacheServiceSpec.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import java.util.UUID
+
+import config.{ CSRCache, SecurityEnvironmentImpl }
+import connectors.ApplicationClient.ApplicationNotFound
+import connectors.UserManagementClient.InvalidCredentialsException
+import connectors.exchange.{ ApplicationResponse, ProgressResponse, UserResponse }
+import connectors.{ ApplicationClient, UserManagementClient }
+import controllers.BaseSpec
+import models.{ CachedData, CachedUser, SecurityUser, UniqueIdentifier }
+import org.mockito.Matchers.{ eq => eqTo, _ }
+import org.mockito.Mockito._
+import org.scalatest.MustMatchers
+import org.scalatest.concurrent.ScalaFutures
+import play.api.libs.json.{ JsString, Reads }
+import play.api.mvc.Request
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.cache.client.KeyStoreEntryValidationException
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
+import scala.language.postfixOps
+
+class UserCacheServiceSpec extends BaseSpec with MustMatchers with ScalaFutures {
+
+  "refreshCachedUser" should {
+    "return a user and application CachedData when both are found" in new TestFixture {
+      val result = userAndApplicationCacheService.refreshCachedUser(testUserId).futureValue
+
+      result mustBe an[CachedData]
+      result.application mustNot be(None)
+    }
+
+    "return a user only when no application is found" in new TestFixture {
+      val result = userOnlyCacheService.refreshCachedUser(testUserId).futureValue
+
+      result mustBe an[CachedData]
+      result.application mustBe None
+    }
+
+    "throw an Invalid Credentials exception when no user is found" in new TestFixture {
+      val result = noUserCacheService.refreshCachedUser(testUserId).failed.futureValue
+
+      result mustBe an[InvalidCredentialsException]
+    }
+  }
+
+  trait TestFixture {
+
+    val testUserId = UniqueIdentifier(UUID.randomUUID())
+    val testApplicationId = UniqueIdentifier(UUID.randomUUID())
+    val testUserResponse = UserResponse(
+      "Barry",
+      "Smith",
+      Some("Barry"),
+      isActive = true,
+      testUserId,
+      "barry@smith.com",
+      "UNLOCKED",
+      "candidate"
+    )
+    val testApplicationResponse = ApplicationResponse(
+      testApplicationId,
+      "SUBMITTED",
+      testUserId,
+      ProgressResponse(testApplicationId.toString()),
+      None
+    )
+
+    implicit val request = FakeRequest(GET, "")
+
+    implicit val hc = new HeaderCarrier()
+
+    val mockApplicationClient = mock[ApplicationClient]
+    val mockUserManagementClient = mock[UserManagementClient]
+
+    lazy val noUserCacheService = makeUserCacheService {
+      when(mockUserManagementClient.findByUserId(any[UniqueIdentifier]())(any[HeaderCarrier]())).thenReturn(Future.failed(
+        new InvalidCredentialsException()
+      ))
+    }
+
+    lazy val userOnlyCacheService = makeUserCacheService {
+      when(mockUserManagementClient.findByUserId(any[UniqueIdentifier]())(any[HeaderCarrier]())).thenReturn(Future.successful(
+        testUserResponse
+      ))
+      when(mockApplicationClient.findApplication(any[UniqueIdentifier](), any[String]())(any[HeaderCarrier]())).thenReturn(Future.failed(
+        new ApplicationNotFound()
+      ))
+    }
+
+    lazy val userAndApplicationCacheService = makeUserCacheService {
+      when(mockUserManagementClient.findByUserId(any[UniqueIdentifier]())(any[HeaderCarrier]())).thenReturn(Future.successful(
+        testUserResponse
+      ))
+      when(mockApplicationClient.findApplication(any[UniqueIdentifier](), any[String]())(any[HeaderCarrier]())).thenReturn(Future.successful(
+        testApplicationResponse
+      ))
+    }
+
+    def makeUserCacheService(mockSetup: => Unit): UserCacheService = {
+      mockSetup
+      new UserCacheService(mockApplicationClient, mockUserManagementClient) {
+        override def save(user: CachedData)(implicit hc: HeaderCarrier): Future[CachedData] = Future.successful(user)
+      }
+    }
+  }
+}

--- a/test/security/UserCacheServiceSpec.scala
+++ b/test/security/UserCacheServiceSpec.scala
@@ -24,7 +24,8 @@ import connectors.UserManagementClient.InvalidCredentialsException
 import connectors.exchange.{ ApplicationResponse, ProgressResponse, UserResponse }
 import connectors.{ ApplicationClient, UserManagementClient }
 import controllers.BaseSpec
-import models.{ CachedData, CachedUser, SecurityUser, UniqueIdentifier }
+import models.ApplicationData.ApplicationStatus
+import models._
 import org.mockito.Matchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
 import org.scalatest.MustMatchers
@@ -46,7 +47,8 @@ class UserCacheServiceSpec extends BaseSpec with MustMatchers with ScalaFutures 
       val result = userAndApplicationCacheService.refreshCachedUser(testUserId).futureValue
 
       result mustBe an[CachedData]
-      result.application mustNot be(None)
+      result.user mustBe expectedCachedDataUser
+      result.application mustBe Some(expectedCachedDataApplication)
     }
 
     "return a user only when no application is found" in new TestFixture {
@@ -54,6 +56,7 @@ class UserCacheServiceSpec extends BaseSpec with MustMatchers with ScalaFutures 
 
       result mustBe an[CachedData]
       result.application mustBe None
+      result.user mustBe expectedCachedDataUser
     }
 
     "throw an Invalid Credentials exception when no user is found" in new TestFixture {
@@ -82,6 +85,22 @@ class UserCacheServiceSpec extends BaseSpec with MustMatchers with ScalaFutures 
       "SUBMITTED",
       testUserId,
       ProgressResponse(testApplicationId.toString()),
+      None
+    )
+    val expectedCachedDataUser = CachedUser(
+      testUserId,
+      testUserResponse.firstName,
+      testUserResponse.lastName,
+      testUserResponse.preferredName,
+      testUserResponse.email,
+      testUserResponse.isActive,
+      testUserResponse.lockStatus
+    )
+    val expectedCachedDataApplication = ApplicationData(
+      testApplicationId,
+      testUserId,
+      ApplicationStatus.withName(testApplicationResponse.applicationStatus),
+      Progress.fromProgressRespToAppProgress(testApplicationResponse.progressResponse),
       None
     )
 

--- a/test/testables/SecureActionsSpec.scala
+++ b/test/testables/SecureActionsSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testables
+
+import com.mohiva.play.silhouette.api.actions.SecuredRequest
+import config.CSRCache
+import controllers.BaseSpec
+import models.CachedData
+import org.scalatest.MustMatchers
+import org.scalatestplus.play.PlaySpec
+import play.api.mvc.{ AnyContent, Request, Result }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import security.Roles.{ CsrAuthorization, NoRole }
+import security.{ SecureActions, SecurityEnvironment }
+
+import scala.concurrent.Future
+import org.mockito.Matchers.{ eq => eqTo, _ }
+import org.mockito.Mockito._
+import uk.gov.hmrc.play.http.HeaderCarrier
+import play.api.mvc.Results._
+
+class SecureActionsSpec extends BaseSpec with MustMatchers {
+  val request = FakeRequest(GET, "")
+
+  "CSRSecureAction" should {
+    "return an ok" in new TestFixture {
+      val result = sut.CSRSecureAction(NoRole) { implicit request =>
+        implicit cachedData =>
+        Future.successful(Ok)
+      }
+
+      print(s"Result = $result\n")
+    }
+
+    "return an ok and cache a new record when retrieval fails due to a parsing exception" in new TestFixture {
+    }
+  }
+
+  "CSRSecureAppAction" should {
+
+  }
+
+  "CSRUserAwareAction" should {
+
+  }
+
+  trait TestFixture {
+
+    val securityEnvironment = mock[SecurityEnvironment]
+    val cache = mock[CSRCache]
+
+    val sut = new SecureActions(securityEnvironment, cache) {
+
+      implicit def hc(implicit request: Request[_]): HeaderCarrier = HeaderCarrier()
+
+      // scalastyle:off
+      private def SecuredActionWithCSRAuthorisation[T](
+                                                        originalRequest: SecuredRequest[AnyContent],
+                                                        block: SecuredRequest[_] => T => Future[Result],
+                                                        role: CsrAuthorization,
+                                                        cachedData: CachedData,
+                                                        valueForActionBlock: => T
+                                                      ): Future[Result] = {
+        Future.successful(Ok)
+      }
+      // scalastyle:on
+    }
+  }
+}

--- a/test/testables/SecureActionsSpec.scala
+++ b/test/testables/SecureActionsSpec.scala
@@ -16,38 +16,71 @@
 
 package testables
 
-import com.mohiva.play.silhouette.api.actions.SecuredRequest
-import config.CSRCache
+import java.util.UUID
+
+import com.mohiva.play.silhouette.api.LoginInfo
+import com.mohiva.play.silhouette.impl.User
+import com.mohiva.play.silhouette.test._
+import com.mohiva.play.silhouette.impl.authenticators.{CookieAuthenticator, SessionAuthenticator}
+import com.mohiva.play.silhouette.test.FakeEnvironment
+import config.{CSRCache, SecurityEnvironmentImpl}
 import controllers.BaseSpec
-import models.CachedData
+import models.{CachedData, CachedUser, SecurityUser, UniqueIdentifier}
+import org.joda.time.DateTime
 import org.scalatest.MustMatchers
 import org.scalatestplus.play.PlaySpec
-import play.api.mvc.{ AnyContent, Request, Result }
-import play.api.test.FakeRequest
+import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
-import security.Roles.{ CsrAuthorization, NoRole }
-import security.{ SecureActions, SecurityEnvironment }
+import security.Roles.{CsrAuthorization, NoRole}
+import security.{SecureActions, SecurityEnvironment}
 
 import scala.concurrent.Future
-import org.mockito.Matchers.{ eq => eqTo, _ }
+import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
+import play.api.libs.json.Reads
 import uk.gov.hmrc.play.http.HeaderCarrier
 import play.api.mvc.Results._
+import play.api.test.FakeRequest
 
-class SecureActionsSpec extends BaseSpec with MustMatchers {
-  val request = FakeRequest(GET, "")
+class SecureActionsSpec extends BaseSpec with MustMatchers with ScalaFutures {
 
   "CSRSecureAction" should {
-    "return an ok" in new TestFixture {
-      val result = sut.CSRSecureAction(NoRole) { implicit request =>
+    "return an ok with a valid cache entry and identity" in new TestFixture {
+
+      val result = userOnlyCacheEntryController.CSRSecureAction(NoRole) { implicit request =>
         implicit cachedData =>
         Future.successful(Ok)
-      }
+      }.apply(identityRequest)
 
-      print(s"Result = $result\n")
+      status(result) mustBe OK
+      contentAsString(result) must contain("")
+
+      print(s"Result = ${result}\n")
     }
 
     "return an ok and cache a new record when retrieval fails due to a parsing exception" in new TestFixture {
+    }
+
+    "return a redirect when no cache entry exists" ignore {
+      /*val result = noCacheEntryController.CSRSecureAction(NoRole) { implicit request =>
+        implicit cachedData =>
+          Future.successful(Ok)
+      }.apply(identityRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some("/fset-fast-stream/signin")*/
+    }
+
+    "return a redirect when there is no identity" ignore {
+      /*val result = plainController.CSRSecureAction(NoRole) { implicit request =>
+        implicit cachedData =>
+          Future.successful(Ok)
+      }.apply(noIdentityRequest)
+
+      status(result) mustBe OK
+
+      print(s"Result = ${result}\n")*/
     }
   }
 
@@ -61,24 +94,72 @@ class SecureActionsSpec extends BaseSpec with MustMatchers {
 
   trait TestFixture {
 
-    val securityEnvironment = mock[SecurityEnvironment]
-    val cache = mock[CSRCache]
+    val testUserId = UniqueIdentifier(UUID.randomUUID())
 
-    val sut = new SecureActions(securityEnvironment, cache) {
+    implicit def hc(implicit request: Request[_]): HeaderCarrier = HeaderCarrier()
+    implicit val noIdentityRequest = FakeRequest(GET, "")
 
-      implicit def hc(implicit request: Request[_]): HeaderCarrier = HeaderCarrier()
+    // Fake Silhouette environment
+    val identity = User(LoginInfo("provId", testUserId.toString()), None, None, None, None, None)
+    val authenticator = new SessionAuthenticator(identity.loginInfo, DateTime.now(), DateTime.now().plusDays(1), None, None)
+    implicit val fakeEnv = FakeEnvironment[SecurityUser, SessionAuthenticator](Seq(identity.loginInfo -> SecurityUser(testUserId.toString())))
+    implicit val identityRequest = FakeRequest().withAuthenticator(authenticator)
 
-      // scalastyle:off
-      private def SecuredActionWithCSRAuthorisation[T](
-                                                        originalRequest: SecuredRequest[AnyContent],
-                                                        block: SecuredRequest[_] => T => Future[Result],
-                                                        role: CsrAuthorization,
-                                                        cachedData: CachedData,
-                                                        valueForActionBlock: => T
-                                                      ): Future[Result] = {
-        Future.successful(Ok)
+    val mockSecurityEnvironment = mock[SecurityEnvironment]
+    val mockCacheClient = mock[CSRCache]
+
+    implicit val hc = new HeaderCarrier()
+
+    lazy val plainController = makeSecureActions {
+    }
+
+    lazy val noCacheEntryController = makeSecureActions {
+      when(mockCacheClient.fetchAndGetEntry(any[String]())(any[HeaderCarrier](), any[Reads[_]]())).thenReturn(
+        Future.successful(None)
+      )
+    }
+
+    lazy val userOnlyCacheEntryController = makeSecureActions {
+      when(mockCacheClient.fetchAndGetEntry[CachedData](any[String]())(any[HeaderCarrier](), any[Reads[CachedData]]())).thenReturn(
+        Future.successful(Some(
+          CachedData(
+            CachedUser(
+              userID = testUserId,
+              firstName = "Clive",
+              lastName = "Johnson",
+              preferredName = Some("Clive"),
+              email = "clivejohnson1234@mailinator.com",
+              isActive = true,
+              "UNLOCKED"
+            ),
+            None
+          )
+        ))
+      )
+    }
+
+    def makeSecureActions(mockSetup: => Unit): SecureActions = {
+      mockSetup
+      new SecureActions {
+
+        val cacheClient = mockCacheClient
+        // override protected def env: SecurityEnvironment = mockSecurityEnvironment
+
+        implicit def hc(implicit request: Request[_]): HeaderCarrier = new HeaderCarrier()
+
+        // scalastyle:off
+        private def SecuredActionWithCSRAuthorisation[T](
+                                                          originalRequest: SecuredRequest[AnyContent],
+                                                          block: SecuredRequest[_] => T => Future[Result],
+                                                          role: CsrAuthorization,
+                                                          cachedData: CachedData,
+                                                          valueForActionBlock: => T
+                                                        ): Future[Result] = {
+          Future.successful(Ok)
+        }
+
+        // scalastyle:on
       }
-      // scalastyle:on
     }
   }
 }

--- a/test/testables/SecureActionsSpec.scala
+++ b/test/testables/SecureActionsSpec.scala
@@ -14,174 +14,112 @@
  * limitations under the License.
  */
 
-package testables
+package security
 
 import java.util.UUID
 
-import com.mohiva.play.silhouette.api.services.{AuthenticatorService, IdentityService}
-import com.mohiva.play.silhouette.api.util.{Clock, FingerprintGenerator}
-import com.mohiva.play.silhouette.api.{EventBus, LoginInfo, Provider}
+import com.mohiva.play.silhouette.api.actions.SecuredRequest
+import com.mohiva.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService, IdentityService }
+import com.mohiva.play.silhouette.api.util.{ Clock, FingerprintGenerator }
+import com.mohiva.play.silhouette.api.{ Environment, EventBus, LoginInfo, Provider }
 import com.mohiva.play.silhouette.impl.User
 import com.mohiva.play.silhouette.test._
 import com.mohiva.play.silhouette.impl.authenticators._
 import com.mohiva.play.silhouette.impl.util.DefaultFingerprintGenerator
 import com.mohiva.play.silhouette.test.FakeEnvironment
-import config.{CSRCache, CSRHttp, SecurityEnvironmentImpl}
-import connectors.{ApplicationClient, UserManagementClient}
+import config.{ CSRCache, CSRHttp, SecurityEnvironmentImpl }
+import connectors.{ ApplicationClient, UserManagementClient }
 import controllers.BaseSpec
-import models.{CachedData, CachedUser, SecurityUser, UniqueIdentifier}
+import models.{ CachedData, CachedUser, SecurityUser, UniqueIdentifier }
 import org.joda.time.DateTime
 import org.scalatest.MustMatchers
 import org.scalatestplus.play.PlaySpec
-import play.api.mvc.{AnyContent, Request, Result}
+import play.api.mvc.{ AnyContent, Request, Result }
 import play.api.test.Helpers._
-import security.Roles.{CsrAuthorization, NoRole}
+import security.Roles.{ CsrAuthorization, NoRole }
 import security._
 
 import scala.concurrent.Future
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.Matchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.Play
-import play.api.libs.json.Reads
+import play.api.libs.json.{ JsString, Reads }
 import uk.gov.hmrc.play.http.HeaderCarrier
 import play.api.mvc.Results._
 import play.api.test.FakeRequest
+import play.filters.csrf.CSRF
+import uk.gov.hmrc.http.cache.client.KeyStoreEntryValidationException
+
+import language.postfixOps
 
 class SecureActionsSpec extends BaseSpec with MustMatchers with ScalaFutures {
 
-  "CSRSecureAction" should {
-    "return an ok with a valid cache entry and identity" in new TestFixture {
+  "getCachedData" should {
+    "return cachedData when parsing succeeds" in new TestFixture {
 
-      val result = userOnlyCacheEntryController.CSRSecureAction(NoRole) { implicit request =>
-        implicit cachedData =>
-        Future.successful(Ok)
-      }.apply(identityRequest)
+      val result = successfulCacheParseController.getCachedData(testSecurityUser).futureValue
 
-      status(result) mustBe 303 // Olly: This should be 200, 303 so this status() call succeeds and i can print $result
-      print(s"Result = ${result}\n")
-      contentAsString(result) must contain("")
+      result.get mustBe an[CachedData]
     }
 
-    "return an ok and cache a new record when retrieval fails due to a parsing exception" in new TestFixture {
+    "Call for cache refresh when a parsing error occurs" in new TestFixture {
+
+      val result = unSuccessfulCacheParseController.getCachedData(testSecurityUser).futureValue
+
+      result.get mustBe an[CachedData]
     }
-
-    "return a redirect when no cache entry exists" ignore {
-      /*val result = noCacheEntryController.CSRSecureAction(NoRole) { implicit request =>
-        implicit cachedData =>
-          Future.successful(Ok)
-      }.apply(identityRequest)
-
-      status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some("/fset-fast-stream/signin")*/
-    }
-
-    "return a redirect when there is no identity" ignore {
-      /*val result = plainController.CSRSecureAction(NoRole) { implicit request =>
-        implicit cachedData =>
-          Future.successful(Ok)
-      }.apply(noIdentityRequest)
-
-      status(result) mustBe OK
-
-      print(s"Result = ${result}\n")*/
-    }
-  }
-
-  "CSRSecureAppAction" should {
-
-  }
-
-  "CSRUserAwareAction" should {
-
   }
 
   trait TestFixture {
 
     val testUserId = UniqueIdentifier(UUID.randomUUID())
+    val testSecurityUser = SecurityUser(testUserId.toString())
+    val testCachedData = CachedData(
+      CachedUser(
+        testUserId,
+        "firstName",
+        "lastName",
+        Some("preferredName"),
+        "a@b.com",
+        isActive = true,
+        "UNLOCKED"
+      ), None)
 
-    implicit def hc(implicit request: Request[_]): HeaderCarrier = HeaderCarrier()
-    implicit val noIdentityRequest = FakeRequest(GET, "")
-
-    // Fake Silhouette environment
-    val identity = User(LoginInfo("provId", testUserId.toString()), None, None, None, None, None)
-    val authenticator = new SessionAuthenticator(identity.loginInfo, DateTime.now(), DateTime.now().plusDays(1), None, None)
-    val authenticatorService = FakeSessionAuthenticatorService()
-    implicit val env = FakeEnvironment[SecurityUser, SessionAuthenticator](Seq(identity.loginInfo -> SecurityUser(testUserId.toString())))
-    implicit val identityRequest = FakeRequest().withAuthenticator(authenticator)(env)
-
-    val mockSecurityEnvironment = mock[SecurityEnvironment]
-    val mockCacheClient = mock[CSRCache]
+    implicit val request = FakeRequest(GET, "")
 
     implicit val hc = new HeaderCarrier()
 
-    lazy val plainController = makeSecureActions {
+    val mockCacheClient = mock[CSRCache]
+    val mockUserCacheService = mock[UserCacheService]
+
+    lazy val successfulCacheParseController = makeSecureActions {
+      when(mockCacheClient.fetchAndGetEntry[CachedData](any())(
+        any[HeaderCarrier](), any[Reads[CachedData]]())).thenReturn(Future.successful(Some(
+          testCachedData
+      )))
     }
 
-    lazy val noCacheEntryController = makeSecureActions {
-      when(mockCacheClient.fetchAndGetEntry(any[String]())(any[HeaderCarrier](), any[Reads[_]]())).thenReturn(
-        Future.successful(None)
-      )
-    }
-
-    lazy val userOnlyCacheEntryController = makeSecureActions {
-      when(mockCacheClient.fetchAndGetEntry[CachedData](any[String]())(any[HeaderCarrier](), any[Reads[CachedData]]())).thenReturn(
-        Future.successful(Some(
-          CachedData(
-            CachedUser(
-              userID = testUserId,
-              firstName = "Clive",
-              lastName = "Johnson",
-              preferredName = Some("Clive"),
-              email = "clivejohnson1234@mailinator.com",
-              isActive = true,
-              "UNLOCKED"
-            ),
-            None
-          )
-        ))
+    lazy val unSuccessfulCacheParseController = makeSecureActions {
+      when(mockCacheClient.fetchAndGetEntry[CachedData](any())(
+        any[HeaderCarrier](), any[Reads[CachedData]]())).thenReturn(Future.failed(
+        new KeyStoreEntryValidationException("WantedKey", JsString("/wantedKey"), CachedData.getClass, Seq())
+      ))
+      when(mockUserCacheService.refreshCachedUser(any[UniqueIdentifier]())(any[HeaderCarrier](), any[Request[_]]())).thenReturn(
+        Future.successful(testCachedData)
       )
     }
 
     def makeSecureActions(mockSetup: => Unit): SecureActions = {
       mockSetup
       new SecureActions {
-
         val cacheClient = mockCacheClient
-        override protected def env: SecurityEnvironment = new SecurityEnvironment {
-          override lazy val eventBus: EventBus = EventBus()
-
-          override val userService = new UserCacheService(ApplicationClient, UserManagementClient)
-          override val identityService = userService
-
-          override lazy val authenticatorService: SessionAuthenticatorService = new SessionAuthenticatorService(SessionAuthenticatorSettings(
-            sessionKey = Play.configuration.getString("silhouette.authenticator.sessionKey").get,
-            encryptAuthenticator = Play.configuration.getBoolean("silhouette.authenticator.encryptAuthenticator").get,
-            useFingerprinting = Play.configuration.getBoolean("silhouette.authenticator.useFingerprinting").get,
-            authenticatorIdleTimeout = Play.configuration.getInt("silhouette.authenticator.authenticatorIdleTimeout"),
-            authenticatorExpiry = Play.configuration.getInt("silhouette.authenticator.authenticatorExpiry").get
-          ), new DefaultFingerprintGenerator(false), Clock())
-
-          override lazy val credentialsProvider = mock[CsrCredentialsProvider]
-
-          override def providers = Map(credentialsProvider.id -> credentialsProvider)
-          val http: CSRHttp = CSRHttp
-        }
 
         implicit def hc(implicit request: Request[_]): HeaderCarrier = new HeaderCarrier()
 
-        // scalastyle:off
-        private def SecuredActionWithCSRAuthorisation[T](
-                                                          originalRequest: SecuredRequest[AnyContent],
-                                                          block: SecuredRequest[_] => T => Future[Result],
-                                                          role: CsrAuthorization,
-                                                          cachedData: CachedData,
-                                                          valueForActionBlock: => T
-                                                        ): Future[Result] = {
-          Future.successful(Ok)
+        override protected def env: SecurityEnvironment = new SecurityEnvironmentImpl {
+           override val userService = mockUserCacheService
         }
-
-        // scalastyle:on
       }
     }
   }


### PR DESCRIPTION
Cache was not previously being injected so was hard to test, injecting the cache has required changes to all the controllers - please run acceptance, it is fine for me but double confirmation is a good idea.