### PR TITLE
Minor edip fixes

### DIFF
--- a/app/views/application/civilServiceExperienceDetails/civilServantsContent.scala.html
+++ b/app/views/application/civilServiceExperienceDetails/civilServantsContent.scala.html
@@ -9,7 +9,7 @@
             <li>Government Operational Research Service</li>
             <li>Government Social Research Service</li>
         </ul>
-        <p>Check the <a href="http://www.faststream.gov.uk/faqs/" rel="external" target="_blank">eligibility requirements</a>for more information.</p>
+        <p>Check the <a href="https://www.faststream.gov.uk/faqs/" rel="external" target="_blank">eligibility requirements</a>for more information.</p>
     </div>
     <div class="panel-indent text">
         <p>If you're currently a civil servant, or have previously worked for the Civil Service, make sure you read the <a href="https://www.gov.uk/guidance/training-and-development-opportunities-in-the-the-civil-service#join-the-fast-stream" rel="external" target="_blank">conditions that apply</a>.</p>

--- a/app/views/application/civilServiceExperienceDetails/civilServiceExperienceDetailsPanel.scala.html
+++ b/app/views/application/civilServiceExperienceDetails/civilServiceExperienceDetailsPanel.scala.html
@@ -3,7 +3,7 @@
 @import helpers.CSRFieldConstructor._
 @import views.html.widgets.{checkbox, yesNoRadioWithTogglePanel}
 
-<section class="clearfix" id="civilServantQuestion">
+<section class="clearfix section-border" id="civilServantQuestion">
     <div class="text">
         <h2 class="heading-medium">Are you currently a civil servant, or have you been on a diversity internship, or the Fast Track?</h2>
     </div>

--- a/app/views/application/civilServiceExperienceDetails/fastPassCertificatePanel.scala.html
+++ b/app/views/application/civilServiceExperienceDetails/fastPassCertificatePanel.scala.html
@@ -9,7 +9,7 @@
          '_label -> "Did you receive a Fast Pass?") {
         <div id="civilServiceExperienceDetails_fastPassReceived-panel-yes" class="toggle-content">
             <div class="panel-indent text">
-                <p>If you've completed the <a rel="external" target="_blank" href="http://www.faststream.gov.uk/summer-diversity-internship-programme/">Summer Diversity Internship Programme (SDIP)</a> this year and have received a Fast Pass you don't need to complete the online tests.</p>
+                <p>If you've completed the <a rel="external" target="_blank" href="https://www.faststream.gov.uk/summer-diversity-internship-programme/">Summer Diversity Internship Programme (SDIP)</a> this year and have received a Fast Pass you don't need to complete the online tests.</p>
             </div>
             @helper.inputText(form("civilServiceExperienceDetails.certificateNumber"),
                 'id -> "civilServiceExperienceDetails.certificateNumber",

--- a/app/views/application/civilServiceExperienceDetails/fastTrackContent.scala.html
+++ b/app/views/application/civilServiceExperienceDetails/fastTrackContent.scala.html
@@ -9,7 +9,7 @@
             <li>Government Operational Research Service</li>
             <li>Government Social Research Service</li>
         </ul>
-        <p>Check the <a href="http://www.faststream.gov.uk/faqs/" rel="external" target="_blank">eligibility requirements</a>for more information.</p>
+        <p>Check the <a href="https://www.faststream.gov.uk/faqs/" rel="external" target="_blank">eligibility requirements</a>for more information.</p>
     </div>
     <div class="panel-indent text">
         <p>If you're currently a civil servant, or have previously worked for the Civil Service, make sure you read the <a href="https://www.gov.uk/guidance/training-and-development-opportunities-in-the-the-civil-service#join-the-fast-stream" rel="external" target="_blank">conditions that apply</a>.</p>

--- a/app/views/application/generalDetails.scala.html
+++ b/app/views/application/generalDetails.scala.html
@@ -20,7 +20,7 @@
         @helper.CSRF.formField
         @applicationRoute(optCachedData)
         @nameAndDateOfBirth(details)
-        @contactDetails(details)
+        @contactDetails(details, isLastSection = optCachedData.exists(cachedData => RoleUtils.isEdip(optCachedData)))
         @if(optCachedData.exists(cachedData => EditPersonalDetailsAndContinueRole.isAuthorized(cachedData)) &&
             !RoleUtils.isEdip(optCachedData)){
             @civilServiceExperienceDetailsPanel(details)

--- a/app/views/application/personalDetails/contactDetails.scala.html
+++ b/app/views/application/personalDetails/contactDetails.scala.html
@@ -1,4 +1,4 @@
-@(form: Form[_root_.forms.GeneralDetailsForm.Data])(implicit lang: play.api.i18n.Lang)
+@(form: Form[_root_.forms.GeneralDetailsForm.Data], isLastSection: Boolean)(implicit lang: play.api.i18n.Lang)
 
 @import helpers.CSRFieldConstructor._
 @import views.html.widgets.checkbox
@@ -10,7 +10,7 @@
     }
 }
 
-<section class="section-border">
+<section @if(!isLastSection){ class="section-border" } >
     <h2 class="heading-medium">Contact details</h2>
 
     <div class="form-group">

--- a/app/views/application/schemePreferences/schemesCheckboxGroup.scala.html
+++ b/app/views/application/schemePreferences/schemesCheckboxGroup.scala.html
@@ -26,7 +26,7 @@
                         @Messages("qualification."+qualification+".description")
                         @if(specific){
                             <a class="font-xsmall inl-block"
-                               href='http://www.faststream.gov.uk/@Messages("scheme."+schemeId+".link")'
+                               href='https://www.faststream.gov.uk/@Messages("scheme."+schemeId+".link")'
                                rel="external" target="_blank">(Specific requirements)</a>
                         }
                     </span>

--- a/app/views/home/dashboard.scala.html
+++ b/app/views/home/dashboard.scala.html
@@ -133,7 +133,7 @@
                                     <p data-hidesdip>If you pass the online tests, you'll be invited to attend an
                                         assessment centre.</p>
                                 }
-                                <p><a href="http://www.faststream.gov.uk/faqs/"
+                                <p><a href="https://www.faststream.gov.uk/faqs/"
                                 rel="external" target="_blank">Find out more about the assessment day</a></p>
                             } else { @if(isEdip(usr)) {
                                 @home.edipExtraInfo(usr)
@@ -151,7 +151,7 @@
                             @if(isFaststream(usr)) {
                                 <h2 class="heading-medium ">4. Final stages</h2>
                                 <p>We aim to let you know the outcome of your assessment by January 2017.</p>
-                                <p><a href="http://www.faststream.gov.uk/faqs/"
+                                <p><a href="https://www.faststream.gov.uk/faqs/"
                                 rel="external" target="_blank">
                                     Find out more about what happens after you've been accepted for the Fast Stream</a></p>
                             } else { @if(isEdip(usr)) {

--- a/app/views/home/edipFinalStages.scala.html
+++ b/app/views/home/edipFinalStages.scala.html
@@ -2,6 +2,6 @@
 
 <h2 class="heading-medium ">4. Final stages</h2>
 <p>We aim to let you know the outcome of your phone interview by April 2017.</p>
-<p><a href="http://www.faststream.gov.uk/faqs/" rel="external" target="_blank">
+<p><a href="https://www.faststream.gov.uk/faqs/" rel="external" target="_blank">
     Find out more about what happens after you've been accepted for the Fast Stream
 </a></p>

--- a/app/views/registration/chooseYourRoute.scala.html
+++ b/app/views/registration/chooseYourRoute.scala.html
@@ -25,7 +25,7 @@
                     <li>I meet my schemes eligibility requirements</li>
                 </ul>
                 @yesNoQuestion(form("faststreamEligible"), question = "Are you eligible to apply for the Civil Service Fast Stream?",
-                               noMessage = "You must be eligible to apply for the Civil Service Fast Stream")
+                               noMessage = "You must be eligible to apply for the Civil Service Fast Stream.")
             </div>
         </div>
         <div class="toggle-content form-group form-group-compound" id="edip-elig-describe">
@@ -36,7 +36,7 @@
                 <li>I'm either from a BAME or socially/economically disadvantaged
                     background, or disabled</li>
                 <li>I'm in the first year at university</li>
-                <li>I qualify to apply according to the <a href="http://www.faststream.gov.uk/early-diversity-internship-programme/"
+                <li>I qualify to apply according to the <a href="https://www.faststream.gov.uk/early-diversity-internship-programme/"
                                                             rel="external" target="_blank">eligibility requirements</a></li>
             </ul>
                 @yesNoQuestion(form("edipEligible"), question = "Are you eligible to apply for the Early Diversity Internship Programme (EDIP)?",

--- a/app/views/widgets/onlineTestProgress.scala.html
+++ b/app/views/widgets/onlineTestProgress.scala.html
@@ -73,7 +73,7 @@
                     </ul>
                 }
             }
-            <p id="testsFindoutmore"><a href="http://www.faststream.gov.uk/faqs/" target="_blank" rel="external">Find out more about the online tests</a></p>
+            <p id="testsFindoutmore"><a href="https://www.faststream.gov.uk/faqs/" target="_blank" rel="external">Find out more about the online tests</a></p>
         }
         case (_, _, Some(tests)) if cachedUserData.application.isDefined => {
             <ul class="list-text list-withicons">

--- a/sbtTestRoutes.sh
+++ b/sbtTestRoutes.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sbt -J-Dapplication.router=testOnlyDoNotUseInAppConf.Routes
+sbt -J-Dapplication.router=testOnlyDoNotUseInAppConf.Routes -Dhttp.port=9284


### PR DESCRIPTION
- Fix issue where EDIP signup had page divider at the bottom, between the last form group and button. @charge-valtech can you take a look at some point as to whether the clearfix is in the right place?
- Update links to marketing site to HTTPS, which stops extra redirect and MITM (although that is very low risk, as the marketing site doesn't gather data)
