### PR TITLE
Remove doc sources to reduce build time and reduce tgz size

### DIFF
--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -60,6 +60,7 @@ trait MicroService {
       retrieveManaged := true,
       scalacOptions += "-feature"
     )
+    .settings(sources in (Compile, doc) := Seq.empty)
     .configs(IntegrationTest)
     .settings(pipelineStages := Seq(digest, gzip))
     .settings(inConfig(IntegrationTest)(Defaults.testSettings) : _*)


### PR DESCRIPTION
This has already been done in fset-faststream, and does seem to work nicely