### PR TITLE
Rename the WithdrawApplicationRole

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -69,12 +69,12 @@ abstract class HomeController(applicationClient: ApplicationClient, cacheClient:
       }
   }
 
-  def presentWithdrawApplication = CSRSecureAppAction(WithdrawApplicationRole) { implicit request =>
+  def presentWithdrawApplication = CSRSecureAppAction(AbleToWithdrawApplicationRole) { implicit request =>
     implicit user =>
       Future.successful(Ok(views.html.application.withdraw(WithdrawApplicationForm.form)))
   }
 
-  def withdrawApplication = CSRSecureAppAction(WithdrawApplicationRole) { implicit request =>
+  def withdrawApplication = CSRSecureAppAction(AbleToWithdrawApplicationRole) { implicit request =>
     implicit user =>
 
       def updateApplicationStatus(data: CachedData): CachedData = {

--- a/app/controllers/SubmitApplicationController.scala
+++ b/app/controllers/SubmitApplicationController.scala
@@ -21,7 +21,7 @@ import connectors.ApplicationClient
 import connectors.ApplicationClient.CannotSubmit
 import helpers.NotificationType._
 import models.ApplicationData.ApplicationStatus.SUBMITTED
-import security.Roles.{ SubmitApplicationRole, WithdrawApplicationRole }
+import security.Roles.{ SubmitApplicationRole, AbleToWithdrawApplicationRole }
 
 import scala.concurrent.Future
 
@@ -41,7 +41,7 @@ abstract class SubmitApplicationController(applicationClient: ApplicationClient,
       }
   }
 
-  def success = CSRSecureAppAction(WithdrawApplicationRole) { implicit request =>
+  def success = CSRSecureAppAction(AbleToWithdrawApplicationRole) { implicit request =>
     implicit user =>
       Future.successful(Ok(views.html.application.success()))
   }

--- a/app/models/page/DashboardPage.scala
+++ b/app/models/page/DashboardPage.scala
@@ -153,7 +153,7 @@ object DashboardPage {
   }
 
   private def isApplicationSubmittedAndNotWithdrawn(user: CachedData)(implicit request: RequestHeader, lang: Lang) =
-    WithdrawApplicationRole.isAuthorized(user)
+    AbleToWithdrawApplicationRole.isAuthorized(user)
 
   private def isApplicationWithdrawn(user: CachedData)(implicit request: RequestHeader, lang: Lang) =
     WithdrawnApplicationRole.isAuthorized(user)

--- a/app/security/Roles.scala
+++ b/app/security/Roles.scala
@@ -119,7 +119,7 @@ object Roles {
       activeUserWithActiveApp(user) && statusIn(user)(IN_PROGRESS)
   }
 
-  object WithdrawApplicationRole extends CsrAuthorization {
+  object AbleToWithdrawApplicationRole extends CsrAuthorization {
     override def isAuthorized(user: CachedData)(implicit request: RequestHeader, lang: Lang) =
       activeUserWithActiveApp(user) && !statusIn(user)(IN_PROGRESS, WITHDRAWN, CREATED)
   }
@@ -229,7 +229,7 @@ object Roles {
     DisplayOnlineTestSectionRole -> routes.HomeController.present(),
     ConfirmedAllocatedCandidateRole -> routes.HomeController.present(),
     UnconfirmedAllocatedCandidateRole -> routes.HomeController.present(),
-    WithdrawApplicationRole -> routes.HomeController.present()
+    AbleToWithdrawApplicationRole -> routes.HomeController.present()
   ).reverse
 }
 

--- a/app/views/application/preview.scala.html
+++ b/app/views/application/preview.scala.html
@@ -11,7 +11,7 @@
 @import security.RoleUtils._
 
 @appNotReadOnly(body: Html)= {
-    @if(!WithdrawApplicationRole.isAuthorized(user.get) && !WithdrawnApplicationRole.isAuthorized(user.get)) {@body}
+    @if(!AbleToWithdrawApplicationRole.isAuthorized(user.get) && !WithdrawnApplicationRole.isAuthorized(user.get)) {@body}
 }
 
 

--- a/app/views/home/dashboard.scala.html
+++ b/app/views/home/dashboard.scala.html
@@ -61,7 +61,7 @@
     @renderProgressElement(showLink = (AssistanceDetailsRole.isAuthorized(usr) || hasAssistanceDetails(usr)), checked = hasAssistanceDetails(usr), "assistanceDetailsStep")(routes.AssistanceDetailsController.present()) { Disability and health conditions }
     @renderProgressElement(showLink = QuestionnaireInProgressRole.isAuthorized(usr), checked = PreviewApplicationRole.isAuthorized(usr), "questionnaireStep")(routes.QuestionnaireController.presentStartOrContinue()) { Fill in the diversity questions }
     @renderProgressElement(showLink = PreviewApplicationRole.isAuthorized(usr), checked = SubmitApplicationRole.isAuthorized(usr), "previewStep")(routes.PreviewApplicationController.present()) { Check your application }
-    @renderProgressElement(showLink = SubmitApplicationRole.isAuthorized(usr), checked = WithdrawApplicationRole.isAuthorized(usr), "submitStep")(routes.SubmitApplicationController.present()) { Submit }
+    @renderProgressElement(showLink = SubmitApplicationRole.isAuthorized(usr), checked = AbleToWithdrawApplicationRole.isAuthorized(usr), "submitStep")(routes.SubmitApplicationController.present()) { Submit }
 }
 
 @main_template(title = "Home") {

--- a/app/views/home/viewFinalResults.scala.html
+++ b/app/views/home/viewFinalResults.scala.html
@@ -39,7 +39,7 @@
                 <p class="small-btm-margin">
                     <a class="" id="view-application" href="@routes.PreviewApplicationController.present()">View your submitted application</a>
                 </p>
-                @if(WithdrawApplicationRole.isAuthorized(cachedUser)){
+                @if(AbleToWithdrawApplicationRole.isAuthorized(cachedUser)){
                 <p class="small-btm-margin">
                     <a class="" id="edit-personal-details" href="@routes.PersonalDetailsController.present()">Edit your personal details</a>
                 </p>
@@ -117,7 +117,7 @@
                     <p>You need to complete this step within 7 days of receiving the email.</p>
                 </div>
             </div>
-            @if(WithdrawApplicationRole.isAuthorized(cachedUser)){
+            @if(AbleToWithdrawApplicationRole.isAuthorized(cachedUser)){
                 <h2 class="heading-medium">3. Attend the assessment centre</h2>
                 <div class="text">
                     <div class="">


### PR DESCRIPTION
WithdrawApplicationRole is too similar to WithdrawnApplicationRole.
Withdraw represents the user being in a state were they are able to withdraw their FS application -> renamed to AbleToWithdrawApplicationRole
WithdrawnApplicationRole means that the user has actually withdrawn their application, so it's really a state and not a role.