### PR TITLE
FSET-1455 When reloading the personal details page due to errors, don't disable

### DIFF
--- a/app/views/application/personalDetails/contactDetails.scala.html
+++ b/app/views/application/personalDetails/contactDetails.scala.html
@@ -37,7 +37,7 @@
     </div>
 
 
-    <div id="addressManualInput" class="disabled">
+    <div id="addressManualInput" class=@{if(isOutsideUk) "" else "disabled"}>
         @*
          * The id for the line1 needs to be provided explicitly because otherwise the field is generated
          * with underscore in it. This is making the validation error-link unclickable when address line 1 is omitted.


### PR DESCRIPTION
the address entry form if the isOutsideUk flag is set.