### PR TITLE
FSET-1648: Update exchange object and models to support multiple roles

### DIFF
--- a/app/connectors/UserManagementClient.scala
+++ b/app/connectors/UserManagementClient.scala
@@ -36,7 +36,7 @@ trait UserManagementClient {
 
   def register(email: String, password: String, firstName: String, lastName: String)(implicit hc: HeaderCarrier): Future[UserResponse] =
     http.POST(s"${url.host}/add",
-      AddUserRequest(email.toLowerCase, password, firstName, lastName, role, ServiceName)).map { (resp: HttpResponse) =>
+      AddUserRequest(email.toLowerCase, password, firstName, lastName, List(role), ServiceName)).map { (resp: HttpResponse) =>
       resp.json.as[UserResponse]
     }.recover {
       case Upstream4xxResponse(_, 409, _, _) => throw new EmailTakenException()
@@ -45,7 +45,7 @@ trait UserManagementClient {
   def signIn(email: String, password: String)(implicit hc: HeaderCarrier): Future[UserResponse] =
     http.POST(s"${url.host}/authenticate", SignInRequest(email.toLowerCase, password, ServiceName)).map { (resp: HttpResponse) =>
       val response = resp.json.as[UserResponse]
-      if (response.role != role) throw new InvalidRoleException() else {
+      if (response.roles.head != role) throw new InvalidRoleException() else {
         response
       }
     }.recover {

--- a/app/connectors/UserManagementClient.scala
+++ b/app/connectors/UserManagementClient.scala
@@ -29,13 +29,14 @@ trait UserManagementClient {
 
   private val role = "candidate" // We have only one role for this application
   private lazy val ServiceName = FrontendAppConfig.authConfig.serviceName
+  private val urlPrefix = "faststream"
 
   val http: CSRHttp
 
   import config.FrontendAppConfig.userManagementConfig._
 
   def register(email: String, password: String, firstName: String, lastName: String)(implicit hc: HeaderCarrier): Future[UserResponse] =
-    http.POST(s"${url.host}/add",
+    http.POST(s"${url.host}/$urlPrefix/add",
       AddUserRequest(email.toLowerCase, password, firstName, lastName, List(role), ServiceName)).map { (resp: HttpResponse) =>
       resp.json.as[UserResponse]
     }.recover {
@@ -43,7 +44,7 @@ trait UserManagementClient {
     }
 
   def signIn(email: String, password: String)(implicit hc: HeaderCarrier): Future[UserResponse] =
-    http.POST(s"${url.host}/authenticate", SignInRequest(email.toLowerCase, password, ServiceName)).map { (resp: HttpResponse) =>
+    http.POST(s"${url.host}/$urlPrefix/authenticate", SignInRequest(email.toLowerCase, password, ServiceName)).map { (resp: HttpResponse) =>
       val response = resp.json.as[UserResponse]
       if (response.roles.head != role) throw new InvalidRoleException() else {
         response
@@ -66,13 +67,14 @@ trait UserManagementClient {
       }
 
   def sendResetPwdCode(email: String)(implicit hc: HeaderCarrier): Future[Unit] =
-    http.POST(s"${url.host}/send-reset-password-code", SendPasswordCodeRequest(email.toLowerCase, ServiceName)).map(_ => (): Unit)
+    http.POST(s"${url.host}/$urlPrefix/send-reset-password-code", SendPasswordCodeRequest(email.toLowerCase, ServiceName)).map(_ => (): Unit)
       .recover {
         case e: NotFoundException => throw new InvalidEmailException()
       }
 
   def resetPasswd(email: String, token: String, newPassword: String)(implicit hc: HeaderCarrier): Future[Unit] =
-    http.POST(s"${url.host}/reset-password", ResetPasswordRequest(email.toLowerCase, token, newPassword, ServiceName)).map(_ => (): Unit)
+    http.POST(s"${url.host}/$urlPrefix/reset-password",
+      ResetPasswordRequest(email.toLowerCase, token, newPassword, ServiceName)).map(_ => (): Unit)
       .recover {
         case Upstream4xxResponse(_, 410, _, _) => throw new TokenExpiredException()
         case e: NotFoundException => throw new TokenEmailPairInvalidException()
@@ -83,7 +85,7 @@ trait UserManagementClient {
     http.PUT(s"${url.host}/details/$userId", UpdateDetails(firstName, lastName, preferredName, ServiceName)).map(_ => ())
 
   def failedLogin(email: String)(implicit hc: HeaderCarrier): Future[UserResponse] =
-    http.PUT(s"${url.host}/failedAttempt", EmailWrapper(email.toLowerCase, ServiceName)).map { (resp: HttpResponse) =>
+    http.PUT(s"${url.host}/$urlPrefix/failedAttempt", EmailWrapper(email.toLowerCase, ServiceName)).map { (resp: HttpResponse) =>
       resp.json.as[UserResponse]
     }.recover {
       case e: NotFoundException => throw new InvalidCredentialsException()
@@ -93,14 +95,14 @@ trait UserManagementClient {
     }
 
   def find(email: String)(implicit hc: HeaderCarrier): Future[UserResponse] =
-    http.POST(s"${url.host}/find", EmailWrapper(email.toLowerCase, ServiceName)).map { (resp: HttpResponse) =>
+    http.POST(s"${url.host}/$urlPrefix/find", EmailWrapper(email.toLowerCase, ServiceName)).map { (resp: HttpResponse) =>
       resp.json.as[UserResponse]
     }.recover {
       case e: NotFoundException => throw new InvalidCredentialsException()
     }
 
   def findByUserId(userId: UniqueIdentifier)(implicit hc: HeaderCarrier): Future[UserResponse] =
-    http.POST(s"${url.host}/service/$ServiceName/findUserById", FindByUserIdRequest(userId)).map { (resp: HttpResponse) =>
+    http.POST(s"${url.host}/$urlPrefix/service/$ServiceName/findUserById", FindByUserIdRequest(userId)).map { (resp: HttpResponse) =>
       resp.json.as[UserResponse]
     }.recover {
       case e: NotFoundException => throw new InvalidCredentialsException(s"UserId = $userId")

--- a/app/connectors/exchange/Requests.scala
+++ b/app/connectors/exchange/Requests.scala
@@ -30,7 +30,7 @@ object CreateApplicationRequest {
   implicit val format = Json.format[CreateApplicationRequest]
 }
 
-case class AddUserRequest(email: String, password: String, firstName: String, lastName: String, role: String, service: String)
+case class AddUserRequest(email: String, password: String, firstName: String, lastName: String, roles: List[String], service: String)
 object AddUserRequest {
   implicit val format = Json.format[AddUserRequest]
 }
@@ -38,7 +38,7 @@ object AddUserRequest {
 case class UpdateUserRequest(email: String, password: String, firstName: String, lastName: String,
                              userId: UniqueIdentifier, isActive: Boolean, service: String)
 object UpdateUserRequest {
-  implicit val foramt = Json.format[UpdateUserRequest]
+  implicit val format = Json.format[UpdateUserRequest]
 }
 
 case class SignInRequest(email: String, password: String, service: String)

--- a/app/connectors/exchange/UserResponse.scala
+++ b/app/connectors/exchange/UserResponse.scala
@@ -17,7 +17,7 @@
 package connectors.exchange
 
 import models.UniqueIdentifier
-import play.api.libs.json.Json
+import play.api.libs.json.{ Json, OFormat }
 
 
 case class UserResponse(
@@ -29,13 +29,13 @@ case class UserResponse(
   email: String,
   disabled: Boolean,
   lockStatus: String,
-  role: String,
+  roles: List[String],
   service: String,
   phoneNumber: Option[String]
 )
 
 object UserResponse {
-  implicit val format = Json.format[UserResponse]
+  implicit val format: OFormat[UserResponse] = Json.format[UserResponse]
 
   implicit class exchangeUserToCachedUser(exchUser: UserResponse) {
     def toCached: models.CachedUser =

--- a/test/connectors/UserManagementClientSpec.scala
+++ b/test/connectors/UserManagementClientSpec.scala
@@ -56,7 +56,7 @@ class UserManagementClientSpec extends UnitWithAppSpec with ConnectorSpec {
       response.email mustBe "test@email.com"
       response.firstName mustBe "peter"
       response.lastName mustBe "griffin"
-      response.role mustBe "candidate"
+      response.roles mustBe List("candidate")
       response.isActive mustBe true
     }
 

--- a/test/controllers/ConsiderForSdipControllerSpec.scala
+++ b/test/controllers/ConsiderForSdipControllerSpec.scala
@@ -105,7 +105,8 @@ class ConsiderForSdipControllerSpec extends BaseControllerSpec {
       val archiveEmail = ConsiderMeForSdipHelper.convertToArchiveEmail(currentCandidateWithApp.user.email)
       when(mockUserManagementClient.register(eqTo(archiveEmail), any[String],
         eqTo(currentCandidateWithApp.user.firstName), eqTo(currentCandidateWithApp.user.lastName))(any[HeaderCarrier]))
-        .thenReturn(Future.successful(UserResponse("", "", None, isActive = false, UniqueIdentifier(UUID.randomUUID()), "", disabled=false, "", "", "", None)))
+        .thenReturn(Future.successful(
+          UserResponse("", "", None, isActive = false, UniqueIdentifier(UUID.randomUUID()), "", disabled=false, "", Nil, "", None)))
       when(mockApplicationClient.continueAsSdip(any[UniqueIdentifier], any[UniqueIdentifier])(any[HeaderCarrier]))
         .thenReturn(Future.successful(()))
       when(mockSecurityEnvironment.userService).thenReturn(mockUserService)

--- a/test/security/CsrCredentialsProviderSpec.scala
+++ b/test/security/CsrCredentialsProviderSpec.scala
@@ -98,7 +98,7 @@ class CsrCredentialsProviderSpec extends UnitSpec {
     val LastName = "lastName"
     val PreferredName = "preferredName"
     val Email = "email@mailinator.com"
-    val Role = "role"
+    val Role = List("role")
     val ServiceName = "faststream"
     val Id = "login"
     val Password = "password"

--- a/test/security/UserCacheServiceSpec.scala
+++ b/test/security/UserCacheServiceSpec.scala
@@ -73,7 +73,7 @@ class UserCacheServiceSpec extends UnitSpec {
       "barry@smith.com",
       false,
       "UNLOCKED",
-      "candidate",
+      List("candidate"),
       "faststream",
       None
     )


### PR DESCRIPTION
Although an admin can have multiple roles, a candidate should always have just one role so any check for a candidate role only uses the head of the corresponding user's list of roles.

This PR is accompanied by PRs on the auth-provider, backend, admin-frontend and admin-acceptance-tests.