### PR TITLE
When rendering the numeric test portion of the dashboard for candidates

### DIFF
--- a/app/models/Progress.scala
+++ b/app/models/Progress.scala
@@ -65,8 +65,8 @@ case class Phase3TestProgress(
 
 case class SiftProgress(
   siftEntered: Boolean = false,
-  siftFormsSubmitted: Boolean = false,
-  allSchemesSiftCompleted: Boolean = false
+  siftReady: Boolean = false,
+  siftCompleted: Boolean = false
 )
 
 case class Progress(
@@ -152,8 +152,8 @@ object Progress {
       ),
       siftProgress = SiftProgress(
         siftEntered = progressResponse.siftProgressResponse.siftEntered,
-        siftFormsSubmitted = progressResponse.siftProgressResponse.siftReady,
-        allSchemesSiftCompleted = progressResponse.siftProgressResponse.siftCompleted
+        siftReady = progressResponse.siftProgressResponse.siftReady,
+        siftCompleted = progressResponse.siftProgressResponse.siftCompleted
       ),
       exported = progressResponse.exported,
       updateExported = progressResponse.updateExported,

--- a/app/security/Roles.scala
+++ b/app/security/Roles.scala
@@ -318,9 +318,11 @@ object RoleUtils {
 
   def isPhase3TestsExpired(implicit user: CachedData) = user.application.exists(_.progress.phase3TestProgress.phase3TestsExpired)
 
-  def isSiftEntered(implicit user: CachedData) = user.application.exists(_.progress.siftProgress.siftEntered) && !isSiftComplete
+  def isSiftEntered(implicit user: CachedData) = user.application.exists(_.progress.siftProgress.siftEntered)
 
-  def isSiftComplete(implicit user: CachedData) = user.application.exists(_.progress.siftProgress.allSchemesSiftCompleted)
+  def isSiftReady(implicit user: CachedData) = user.application.exists(_.progress.siftProgress.siftReady)
+
+  def isSiftComplete(implicit user: CachedData) = user.application.exists(_.progress.siftProgress.siftCompleted)
 
   def assessmentCentreFailedToAttend(implicit user: CachedData) = user.application.exists(_.progress.assessmentCentre.failedToAttend)
 

--- a/app/views/home/siftProgress.scala.html
+++ b/app/views/home/siftProgress.scala.html
@@ -2,53 +2,49 @@
 @import models.page.DashboardPage.activateByStep
 @import models.page.PostOnlineTestsStage
 @import models.ApplicationData.ApplicationStatus
-@import security.RoleUtils.isSiftEntered
+@import security.RoleUtils._
 
 @(page: models.page.PostOnlineTestsPage)(implicit request: Request[_])
 
 @renderSchemeForm = {
-    @if(isSiftEntered(page.toCachedData)) {
-        <div class="inner-block-padr" id="schemeForms">
-            <h2 class='heading-medium'>Extra information</h2>
-            <p>At least one of your scheme preferences require you to answer
-                some additional questions.</p>
-            <p>You should complete this within 7 days from the date of your
-                email. Failure to do this will hold up your application.</p>
-            <ul class="list-text list-withicons" data-extrainfolist>
-                @if(!page.haveAdditionalQuestionsBeenSubmitted) {
-                    <li><i class="fa fa-minus the-icon"></i><a href="@routes.SiftQuestionsController.presentGeneralQuestions()">Nationality and higher education</a></li>
-                    @for(curSiftableScheme <- page.userDataWithSchemes.schemesForSiftForms) {
-                    <li><i class="fa fa-minus the-icon"></i>
-                        <a href="@routes.SiftQuestionsController.presentSchemeForm(curSiftableScheme.id)">@{
-                            curSiftableScheme.name
-                            }</a>
-                        <span class="font-xsmall">(this section will require you to answer questions in detail, 300 words or more)</span></li>
-                    }
-                    <li><i class="fa fa-minus the-icon"></i><a href="@routes.SiftQuestionsController.presentPreview()">Preview before you submit</a></li>
-                } else {
-                    <div data-extrainfopanel=""><p>You've submitted all the required information.</p></div>
-                    <ul class="list-text list-withicons" data-extrainfolist=""><li><i class="fa fa-check the-icon"></i><a href="@routes.SiftQuestionsController.presentPreview()">View your submitted answers</a></li></ul>
+    <div class="inner-block-padr" id="schemeForms">
+        <h2 class='heading-medium'>Extra information</h2>
+        <p>At least one of your scheme preferences require you to answer
+            some additional questions.</p>
+        <p>You should complete this within 7 days from the date of your
+            email. Failure to do this will hold up your application.</p>
+        <ul class="list-text list-withicons" data-extrainfolist>
+            @if(!page.haveAdditionalQuestionsBeenSubmitted) {
+                <li><i class="fa fa-minus the-icon"></i><a href="@routes.SiftQuestionsController.presentGeneralQuestions()">Nationality and higher education</a></li>
+                @for(curSiftableScheme <- page.userDataWithSchemes.schemesForSiftForms) {
+                <li><i class="fa fa-minus the-icon"></i>
+                    <a href="@routes.SiftQuestionsController.presentSchemeForm(curSiftableScheme.id)">@{
+                        curSiftableScheme.name
+                        }</a>
+                    <span class="font-xsmall">(this section will require you to answer questions in detail, 300 words or more)</span></li>
                 }
-            </ul>
-        </div>
-    }
+                <li><i class="fa fa-minus the-icon"></i><a href="@routes.SiftQuestionsController.presentPreview()">Preview before you submit</a></li>
+            } else {
+                <div data-extrainfopanel=""><p>You've submitted all the required information.</p></div>
+                <ul class="list-text list-withicons" data-extrainfolist=""><li><i class="fa fa-check the-icon"></i><a href="@routes.SiftQuestionsController.presentPreview()">View your submitted answers</a></li></ul>
+            }
+        </ul>
+    </div>
 }
 
 @renderNumericTest = {
-    @if(isSiftEntered(page.toCachedData)) {
-        <div class="inner-block-padr" id="numericTest">
-            <h2 class="heading-medium">Take a numerical test</h2>
-            <p>At least one of your scheme preferences require you to take a
-                numerical test.</p>
-            <p>You'll be sent an email with a link to start your test. Keep
-                an eye on your email inbox, including your junk mail.</p>
-            <p>You should complete this within 7 days from the date of your
-                email. Failure to do this will hold up your application.</p>
-        </div>
-    }
+    <div class="inner-block-padr" id="numericTest">
+        <h2 class="heading-medium">Take a numerical test</h2>
+        <p>At least one of your scheme preferences require you to take a
+            numerical test.</p>
+        <p>You'll be sent an email with a link to start your test. Keep
+            an eye on your email inbox, including your junk mail.</p>
+        <p>You should complete this within 7 days from the date of your
+            email. Failure to do this will hold up your application.</p>
+    </div>
 }
 
-@renderPassedSectionOne = {
+@renderCompletedSectionOne = {
     <div class="inner-block-padr" id="schemeForms">
         <h2 class='heading-medium'>Extra information</h2>
         <p>You've completed this section</p>
@@ -117,7 +113,7 @@
                         @renderSchemeForm
                         @renderNumericTest
                     } else {
-                        @renderPassedSectionOne
+                        @renderCompletedSectionOne
                     }
                 </li>
                 <li class="second-step">
@@ -130,7 +126,7 @@
                     @if(isSiftEntered(page.toCachedData)) {
                         @renderSchemeForm
                     } else {
-                        @renderPassedSectionOne
+                        @renderCompletedSectionOne
                     }
                 </li>
                 <li class="second-step">
@@ -140,10 +136,10 @@
 
             case (false, true, true) => {
                 <li class="first-step">
-                    @if(isSiftEntered(page.toCachedData)) {
+                    @if(isSiftReady(page.toCachedData)) {
                         @renderNumericTest
                     } else {
-                        @renderPassedSectionOne
+                        @renderCompletedSectionOne
                     }
                 </li>
                 <li class="second-step">

--- a/test/connectors/exchange/ProgressExamples.scala
+++ b/test/connectors/exchange/ProgressExamples.scala
@@ -152,7 +152,7 @@ object ProgressExamples {
     ),
     siftProgress = SiftProgress(
       siftEntered = true,
-      allSchemesSiftCompleted = true
+      siftCompleted = true
     ),
     exported = false,
     updateExported = false,


### PR DESCRIPTION
who don't have any forms, we need to check the siftReady progress state.