### PR TITLE
FSET-1739 Always render the "view submitted answers" link after the candidate has

### DIFF
--- a/app/security/Roles.scala
+++ b/app/security/Roles.scala
@@ -199,7 +199,7 @@ object Roles {
 
   object SchemeSpecificQuestionsRole extends CsrAuthorization {
     override def isAuthorized(user: CachedData)(implicit request: RequestHeader) =
-      activeUserWithActiveApp(user) && statusIn(user)(SIFT) && isSiftEntered(user) && !isSiftComplete(user)
+      activeUserWithActiveApp(user) && isSiftReady(user)
   }
 
   object WithdrawComponent extends AuthorisedUser {

--- a/app/views/home/siftProgress.scala.html
+++ b/app/views/home/siftProgress.scala.html
@@ -52,6 +52,7 @@
     <div class="inner-block-padr" id="schemeForms">
         <h2 class='heading-medium'>Extra information</h2>
         <p>You've completed this section</p>
+        <ul class="list-text list-withicons" data-extrainfolist=""><li><i class="fa fa-check the-icon"></i><a href="@routes.SiftQuestionsController.presentPreview()">View your submitted answers</a></li></ul>
     </div>
 }
 


### PR DESCRIPTION
completed their forms.