### PR TITLE
Updated scheme names (and remove International)

### DIFF
--- a/app/models/SchemeType.scala
+++ b/app/models/SchemeType.scala
@@ -21,10 +21,10 @@ import play.api.libs.json.{ Format, JsString, JsSuccess, JsValue }
 object SchemeType extends Enumeration {
   type SchemeType = Value
 
-  val Commercial, DigitalAndTechnology, DiplomaticService, Finance, Generalist,
-  GovernmentCommunicationService, GovernmentEconomicsService, GovernmentEconomicsServiceDiplomaticService,
+  val Commercial, DigitalAndTechnology, DiplomaticService, DiplomaticServiceEconomists, Finance, Generalist,
+  GovernmentCommunicationService, GovernmentEconomicsService,
   GovernmentOperationalResearchService, GovernmentSocialResearchService,
-  GovernmentStatisticalService, HousesOfParliament, HumanResources, International,
+  GovernmentStatisticalService, HousesOfParliament, HumanResources,
   ProjectDelivery, ScienceAndEngineering, Edip, Sdip, SdipFaststream = Value
 
   implicit val schemeFormat = new Format[SchemeType] {

--- a/conf/messages
+++ b/conf/messages
@@ -111,7 +111,7 @@ civilServiceExperienceType.CivilServantViaFastTrack = I''m currently a civil ser
 civilServiceExperienceType.DiversityInternship = I''ve completed SDIP or EDIP
 internshipType.EDIP = Early Diversity Internship Programme
 internshipType.SDIPPreviousYear = Summer Diversity Internship Programme (previous years)
-internshipType.SDIPCurrentYear = Summer Diversity Internship Programme 2016 (this year)
+internshipType.SDIPCurrentYear = Summer Diversity Internship Programme 2017 (this year)
 error.needsEdipCompleted.required = Tell us if you have completed EDIP
 
 #partner graduate programmes
@@ -152,19 +152,18 @@ eligible.required=You can only select preferences you''re eligible for
 alternatives.required=Select whether or not you would consider other schemes
 
 scheme.Commercial.description=Commercial
-scheme.DigitalAndTechnology.description=Digital & Technology
+scheme.DigitalAndTechnology.description=Digital, Data & Technology
 scheme.DiplomaticService.description=Diplomatic Service
+scheme.DiplomaticServiceEconomists.description=Diplomatic Service (Economists)
 scheme.Finance.description=Finance
 scheme.Generalist.description=Generalist
 scheme.GovernmentCommunicationService.description=Government Communication Service
 scheme.GovernmentEconomicsService.description=Government Economics Service
-scheme.GovernmentEconomicsServiceDiplomaticService.description=Government Economics Service - Diplomatic Service
 scheme.GovernmentOperationalResearchService.description=Government Operational Research Service
 scheme.GovernmentSocialResearchService.description=Government Social Research Service
 scheme.GovernmentStatisticalService.description=Government Statistical Service
 scheme.HousesOfParliament.description=Houses of Parliament
 scheme.HumanResources.description=Human Resources
-scheme.International.description=International
 scheme.ProjectDelivery.description=Project Delivery
 scheme.ScienceAndEngineering.description=Science & Engineering
 scheme.Edip.description=Edip
@@ -269,9 +268,9 @@ global.error.InternalServerError500.title=Service unavailable - 500
 global.error.InternalServerError500.heading=Service unavailable
 global.error.InternalServerError500.message=Something went wrong, try again in a few minutes.
 
-dashboard.final.results.Edip=Congratulations, you''ve been successful for the Early Diversity Internship Programme (EDIP).
-dashboard.final.results.Sdip=Congratulations, you''ve been successful for the Summer Diversity Internship Programme (SDIP).
-dashboard.final.results.SdipFaststream=Congratulations, you''ve been successful for the Summer Diversity Internship Programme (SDIP).
+dashboard.final.results.Edip=Congratulations, you''ve been succcessful for the Early Diversity Internship Programme (EDIP).
+dashboard.final.results.Sdip=Congratulations, you''ve been succcessful for the Summer Diversity Internship Programme (SDIP).
+dashboard.final.results.SdipFaststream=Congratulations, you''ve been succcessful for the Summer Diversity Internship Programme (SDIP).
 
 assessmentCentre.analysisExercise.upload.error=There was a problem uploading your analysis exercise. You can try again or speak to an assessor.
 assessmentCentre.analysisExercise.upload.tooBig=Your analysis exercise must be less than 4MB

--- a/conf/messages
+++ b/conf/messages
@@ -268,9 +268,9 @@ global.error.InternalServerError500.title=Service unavailable - 500
 global.error.InternalServerError500.heading=Service unavailable
 global.error.InternalServerError500.message=Something went wrong, try again in a few minutes.
 
-dashboard.final.results.Edip=Congratulations, you''ve been succcessful for the Early Diversity Internship Programme (EDIP).
-dashboard.final.results.Sdip=Congratulations, you''ve been succcessful for the Summer Diversity Internship Programme (SDIP).
-dashboard.final.results.SdipFaststream=Congratulations, you''ve been succcessful for the Summer Diversity Internship Programme (SDIP).
+dashboard.final.results.Edip=Congratulations, you''ve been successful for the Early Diversity Internship Programme (EDIP).
+dashboard.final.results.Sdip=Congratulations, you''ve been successful for the Summer Diversity Internship Programme (SDIP).
+dashboard.final.results.SdipFaststream=Congratulations, you''ve been successful for the Summer Diversity Internship Programme (SDIP).
 
 assessmentCentre.analysisExercise.upload.error=There was a problem uploading your analysis exercise. You can try again or speak to an assessor.
 assessmentCentre.analysisExercise.upload.tooBig=Your analysis exercise must be less than 4MB


### PR DESCRIPTION
This removes International as a scheme, updates DaT to Digital, Data & Technology, and gives GES_DS its proper name of Diplomatic Service (Economists). Also updated year for SDIP. This PR has corresponding backend changes.