### PR TITLE
NOJIRA: File Upload Whitelist

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -115,5 +115,6 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   ).map(_.split(",")).getOrElse(Array.empty).toSeq
 
   lazy val whitelist = whitelistConfig("whitelist")
+  lazy val whitelistFileUpload = whitelistConfig("whitelistFileUpload")
   lazy val whitelistExcluded = whitelistConfig("whitelistExcludedCalls")
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -37,7 +37,7 @@ GET         /application/withdraw                                   controllers.
 POST        /application/withdraw                                   controllers.WithdrawController.withdrawApplication
 GET         /application/withdraw/scheme                            controllers.WithdrawController.presentWithdrawScheme
 POST        /application/withdraw/scheme                            controllers.WithdrawController.withdrawScheme
-POST        /dashboard/submitWrittenExercise                        controllers.HomeController.submitAnalysisExercise
+POST        /file-submission/dashboard/submitWrittenExercise        controllers.HomeController.submitAnalysisExercise
 POST        /application/confirm-assessment-centre-allocation       controllers.HomeController.confirmAssessmentCentreAllocation(allocationVersion: String, eventId: UniqueIdentifier,sessionId: UniqueIdentifier)
 
 GET         /application/details                                    controllers.PersonalDetailsController.present


### PR DESCRIPTION
Please also merge: https://github.tools.tax.service.gov.uk/HMRC/app-config-prod/pull/4221

This change enhances the existing WhitelistFilter.

There is now a 'whitelist' for the site as a whole, but an inner whitelist for fileupload.

Your IP, 1.1.1.1 might get you to the site, but it might not allow you to upload files (paths beginning with /file-submission)

For general launch there's now the option to use '*' in the main whitelist config. So we can "allow everyone into the site, but limit file upload to specific IPs"