### PR TITLE
FSET-1941: Add additional link when a candidate is being invited to an FSB

### DIFF
--- a/app/views/home/siftProgress.scala.html
+++ b/app/views/home/siftProgress.scala.html
@@ -93,10 +93,19 @@
 }
 
 @renderFindMoreAboutFsbDay(a: Option[CandidateAllocationWithEvent]) = {
-    @page.fsbEventScheme(a).flatMap(_.schemeGuide).map { link =>
-        <p><a href="@link" rel="external" target="_blank">
-            Find out more about the assessment centre</a>
-        </p>
+    @page.fsbEventScheme(a).map { schemeConfig =>
+        @schemeConfig.schemeGuide.map { schemeGuideLink =>
+            <p><a href="@schemeGuideLink" rel="external" target="_blank">
+                Find out more about the assessment centre</a>
+                @* TODO: Add this link to configuration *@
+                @if(schemeConfig.id.value.toString == SchemeType.Sdip.toString) {
+                    <br />
+                    You will also need: <a href="https://www.faststream.gov.uk/media/1292/sdip-posting.docx"
+                    rel="external" target="_blank">
+                    The posting preference form</a>
+                }
+            </p>
+        }
     }
 }
 


### PR DESCRIPTION
I've purposefully not added this link to the schemes.yaml and schemes config - it seemed like too wide ranging a change to make at this delicate part of the live process, i've added a TODO for future us to deal with once the campaign is over.